### PR TITLE
fix: remove duplicate assistant message when content+tool_calls present (fixes Gemini #8)

### DIFF
--- a/pentestagent/agents/crew/orchestrator.py
+++ b/pentestagent/agents/crew/orchestrator.py
@@ -184,9 +184,6 @@ class CrewOrchestrator:
                     # If there are tool calls, the content is "thinking" (reasoning before action)
                     if response.content:
                         yield {"phase": "thinking", "content": response.content}
-                        self._messages.append(
-                            {"role": "assistant", "content": response.content}
-                        )
 
                     def get_tc_name(tc):
                         if hasattr(tc, "function"):

--- a/pentestagent/llm/llm.py
+++ b/pentestagent/llm/llm.py
@@ -363,8 +363,8 @@ class LLM:
             "claude-sonnet-4-20250514",
             "claude-opus-4-20250514",
             # Google
-            "gemini-2.5-pro",
-            "gemini-2.5-flash",
+            "gemini/gemini-2.5-pro",
+            "gemini/gemini-2.5-flash",
             # Others via LiteLLM
             "ollama/llama3",
             "ollama/mixtral",


### PR DESCRIPTION
## Summary

- **Root cause of issue #8**: In `CrewOrchestrator.run()`, when the LLM response contains both `content` and `tool_calls`, the code appended two back-to-back assistant messages to `self._messages`:
  1. `{"role": "assistant", "content": response.content}` — bare content message
  2. `{"role": "assistant", "content": ..., "tool_calls": [...]}` — the correct combined message

  Gemini (and technically any spec-compliant LLM API) rejects conversations with consecutive same-role messages. On the very next turn, Gemini would error or cancel the request, which explains why worker agents end up in `cancelled` state.

- **Fix**: Remove the redundant `self._messages.append({"role": "assistant", "content": response.content})` — the content is already included in the combined message that follows it.

- **Bonus fix**: `get_available_models()` listed `gemini-2.5-pro` / `gemini-2.5-flash` without the required `gemini/` prefix. Updated to match the documented correct format.

## Test plan

- [ ] Set `PENTESTAGENT_MODEL=gemini/gemini-2.5-flash` with a valid `GEMINI_API_KEY`
- [ ] Run a crew task and verify worker agents complete (not cancelled/error)
- [ ] Verify single-agent (non-crew) mode still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)