### PR TITLE
feat(mcp): Implement RAG optimizer for tool retrieval and enhance tool indexing

### DIFF
--- a/pentestagent/agents/base_agent.py
+++ b/pentestagent/agents/base_agent.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
     from ..runtime import Runtime
     from ..tools import Tool
 
+_TOOL_LIMIT = 128
+
 
 @dataclass
 class ToolCall:
@@ -35,6 +37,7 @@ class ToolResult:
     result: Optional[str] = None
     error: Optional[str] = None
     success: bool = True
+    suggested_tools: Optional[List["Tool"]] = None
 
 
 @dataclass
@@ -98,6 +101,8 @@ class BaseAgent(ABC):
         self.tools = tools
         self.runtime = runtime
         self.max_iterations = max_iterations
+
+        self.suggested_tools : List[Tool] = []
 
         # Agent runtime state
         self.state_manager = AgentStateManager()
@@ -231,6 +236,8 @@ class BaseAgent(ABC):
 
         iteration = 0
 
+        agent_tools = [t for t in self.tools if t.enabled]
+
         while iteration < self.max_iterations:
             iteration += 1
 
@@ -243,7 +250,7 @@ class BaseAgent(ABC):
             response = await self.llm.generate(
                 system_prompt=self.get_system_prompt(),
                 messages=self._format_messages_for_llm(),
-                tools=[t for t in self.tools if t.enabled],       #Only, enabled tools.
+                tools=agent_tools + self.suggested_tools,       #Only, enabled tools + suggested tools.
             )
 
             # Case 1: Empty response (Error)
@@ -299,6 +306,17 @@ class BaseAgent(ABC):
                 yield thinking_msg
 
             tool_results = await self._execute_tools(response.tool_calls)
+
+            for tool_result in tool_results:
+                #If there are suggested tools to inject (from RAG optimizer, inject them)
+                if tool_result.suggested_tools:
+                    self.suggested_tools += tool_result.suggested_tools   #The suggested tools list is overwritten everytime that the RAG optimizer is called
+
+            # Purge excess suggested tools if total exceeds 128
+            total_tools = len(agent_tools) + len(self.suggested_tools)
+            if total_tools > _TOOL_LIMIT:
+                allowed_suggested = max(0, _TOOL_LIMIT - len(agent_tools))
+                self.suggested_tools = self.suggested_tools[-allowed_suggested:] if allowed_suggested > 0 else []
 
             # Record in history
             assistant_msg = AgentMessage(
@@ -516,12 +534,22 @@ class BaseAgent(ABC):
                     else:
                         result = await tool.execute(arguments, self.runtime)
 
+                    
+                    #Check if the called tool is a MCP RAG Optimizer to obtain the new suggested tools
+
+                    suggested_tools = None
+
+                    if tool.metadata.get("is_rag_optimizer", False):
+                        suggested_tools = tool.metadata.get("top_k_tools", {}).get("retrieved_top_k_tools", None)
+
                     return ToolResult(
                         tool_call_id=tool_call_id,
                         tool_name=name,
                         result=result,
                         success=True,
+                        suggested_tools=suggested_tools
                     )
+            
             except Exception as e:
                 import logging
                 logging.getLogger(__name__).exception("Error executing tool %s: %s", name, e)
@@ -565,7 +593,7 @@ class BaseAgent(ABC):
         Returns:
             The Tool if found, None otherwise
         """
-        for tool in self.tools:
+        for tool in self.tools + self.suggested_tools:
             if tool.name == name:
                 return tool
         # Fallback: if tool not found, attempt to use a generic terminal tool
@@ -828,8 +856,15 @@ Call create_plan with the new steps OR feasible=False."""
         """
         self.tools = [t for t in self.tools if t.name not in [tool.name for tool in tools]]
 
-    def get_tools(self) -> List["Tool"]: 
-        return self.tools
+    def get_tools(self) -> List["Tool"]:
+        retVal : List[Tool] = []
+        for tool in self.tools:
+            if tool.metadata.get("is_rag_optimizer", False):        #Expand tools if we are using the RAG optimizer, so all the tools are listed (although, the only exposed tool is the RAG optimizer tool)
+                suggested_tools = tool.metadata.get("total_tools_indexed", [])
+                retVal += suggested_tools
+            else:
+                retVal.append(tool)
+        return retVal
 
     async def assist(self, message: str) -> AsyncIterator[AgentMessage]:
         """
@@ -858,7 +893,7 @@ Call create_plan with the new steps OR feasible=False."""
         response = await self.llm.generate(
             system_prompt=self.get_system_prompt(mode="assist"),
             messages=self._format_messages_for_llm(),
-            tools=assist_tools,
+            tools=assist_tools + self.suggested_tools,  #Inject suggested tools from RAG optimizer for large MCP servers with lots of tools (more than 128)
         )
 
         # If LLM wants to use tools, execute and return result
@@ -890,6 +925,17 @@ Call create_plan with the new steps OR feasible=False."""
             # NOW execute the tools (this can take a while)
             self.state_manager.transition_to(AgentState.EXECUTING)
             tool_results = await self._execute_tools(response.tool_calls)
+
+            for tool_result in tool_results:
+                #If there are suggested tools to inject (from RAG optimizer, inject them)
+                if tool_result.suggested_tools:
+                    self.suggested_tools += tool_result.suggested_tools   #The suggested tools list is overwritten everytime that the RAG optimizer is called
+
+            # Purge excess suggested tools if total exceeds 128
+            total_tools = len(assist_tools) + len(self.suggested_tools)
+            if total_tools > _TOOL_LIMIT:
+                allowed_suggested = max(0, _TOOL_LIMIT - len(assist_tools))
+                self.suggested_tools = self.suggested_tools[-allowed_suggested:] if allowed_suggested > 0 else []
 
             # Store in history (minimal content to save tokens)
             assistant_msg = AgentMessage(
@@ -943,13 +989,12 @@ Call create_plan with the new steps OR feasible=False."""
         # Pass to the agent only enabled tools.
         interact_tools = [t for t in self.tools if t.name != "finish" and t.enabled]
 
-
         while True:
             # Single LLM call with tools available
             response = await self.llm.generate(
                 system_prompt=self.get_system_prompt(mode="interact"),
                 messages=self._format_messages_for_llm(),
-                tools=interact_tools,
+                tools=interact_tools + self.suggested_tools,     #Inject suggested tools from RAG optimizer for large MCP servers with lots of tools (more than 128)
             )
 
             # If LLM wants to use tools, execute and return result
@@ -989,12 +1034,22 @@ Call create_plan with the new steps OR feasible=False."""
                     tool_result = await coro
                     all_tool_results.append(tool_result)
 
+                    #If there are suggested tools to inject (from RAG optimizer, inject them)
+                    if tool_result.suggested_tools:
+                        self.suggested_tools += tool_result.suggested_tools   #The suggested tools list is overwritten everytime that the RAG optimizer is called
+
                     # Yield each result immediately as it finishes
                     yield AgentMessage(
                         role="tool_result",
                         content="",
                         tool_results=[tool_result],
                     )
+
+                # Purge excess suggested tools if total exceeds 128
+                total_tools = len(interact_tools) + len(self.suggested_tools)
+                if total_tools > _TOOL_LIMIT:
+                    allowed_suggested = max(0, _TOOL_LIMIT - len(interact_tools))
+                    self.suggested_tools = self.suggested_tools[-allowed_suggested:] if allowed_suggested > 0 else []
 
                 # Append the complete set to history once all are done
                 self.conversation_history.append(

--- a/pentestagent/knowledge/__init__.py
+++ b/pentestagent/knowledge/__init__.py
@@ -1,6 +1,6 @@
 """Knowledge and RAG system for PentestAgent."""
 
-from .embeddings import get_embeddings, get_embeddings_local
+from .embeddings import get_embeddings, get_embeddings_local, batch_cosine_similarity, EmbeddingCache
 from .indexer import KnowledgeIndexer
 from .rag import Document, RAGEngine
 
@@ -10,4 +10,6 @@ __all__ = [
     "get_embeddings",
     "get_embeddings_local",
     "KnowledgeIndexer",
+    "batch_cosine_similarity",
+    "EmbeddingCache"
 ]

--- a/pentestagent/mcp/manager.py
+++ b/pentestagent/mcp/manager.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 from abc import ABC
 
-from .tools import create_mcp_tool
+from ..tools import Tool
 from .transport import MCPTransport, StdioTransport, SSETransport
 
 
@@ -251,12 +251,21 @@ class MCPManager:
             for n, s in servers.items()
         ]
     
-    def create_mcp_tools_from_server(self, server: MCPServer) -> List["Tool"]:
-        all_tools = []
-        for tool_def in server.tools:
-            tool = create_mcp_tool(tool_def, server, self)
-            all_tools.append(tool)
-        return all_tools 
+    def create_mcp_tools_from_server(self, server: MCPServer, embedding_model: str = "text-embedding-3-small", rag_top_k: int = 20,) -> List["Tool"]:
+        from .tools import create_mcp_tool
+        from .mcp_rag_optimizer import _TOOL_LIMIT, create_mcp_rag_optimizer
+        all_tools = [create_mcp_tool(tool_def, server, self) for tool_def in server.tools]
+
+        if len(all_tools) <= _TOOL_LIMIT:
+            return all_tools  # under the limit — expose everything directly
+
+        rag_tool = create_mcp_rag_optimizer(
+            all_tools,
+            server,
+            embedding_model=embedding_model,
+            top_k=rag_top_k,
+        )
+        return [rag_tool]
 
 
     async def connect_all(self) -> List["Tool"]:

--- a/pentestagent/mcp/mcp_rag_optimizer.py
+++ b/pentestagent/mcp/mcp_rag_optimizer.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Optional
+import numpy as np
+
+if TYPE_CHECKING:
+    from ..tools import Tool, ToolSchema
+    from manager import MCPServer
+    from ..runtime import Runtime
+
+from ..knowledge import (
+    get_embeddings,
+    batch_cosine_similarity,
+    EmbeddingCache,
+)
+
+_DEFAULT_TOP_K = 20
+_TOOL_LIMIT = 128
+
+
+class ToolIndex:
+    """
+    Vector index over a tool catalogue using LiteLLM embeddings.
+    Embeddings are computed once at build time and cached.
+    """
+
+    def __init__(
+        self,
+        tools: List["Tool"],
+        embedding_model: str = "text-embedding-3-small",
+        cache: Optional[EmbeddingCache] = None,
+    ):
+        self.tools = tools
+        self.embedding_model = embedding_model
+        self.cache = cache or EmbeddingCache(max_size=len(tools) + 256)
+        self._matrix: Optional[np.ndarray] = None  # shape (N, D)
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _tool_text(tool: "Tool") -> str:
+        return f"{tool.name} {tool.description}"
+
+    # ------------------------------------------------------------------
+    def build(self) -> None:
+        """Embed every tool, using the cache to skip already-computed ones."""
+        texts = [self._tool_text(t) for t in self.tools]
+
+        # Separate cached from uncached
+        cached_map: dict[str, np.ndarray] = {}
+        uncached_texts: List[str] = []
+
+        for text in texts:
+            hit = self.cache.get(text)
+            if hit is not None:
+                cached_map[text] = hit
+            else:
+                uncached_texts.append(text)
+
+        # Batch-embed only what's missing
+        if uncached_texts:
+            new_embeddings = get_embeddings(uncached_texts, model=self.embedding_model)
+            for text, emb in zip(uncached_texts, new_embeddings):
+                self.cache.set(text, emb)
+                cached_map[text] = emb
+
+        # Assemble matrix in original tool order
+        self._matrix = np.stack([cached_map[t] for t in texts], axis=0)
+
+    # ------------------------------------------------------------------
+    def search(self, query: str, top_k: int = _DEFAULT_TOP_K) -> List["Tool"]:
+        """Return the top_k tools most relevant to *query*."""
+        if self._matrix is None:
+            self.build()
+
+        assert self._matrix is not None, "ToolIndex.build() failed to populate _matrix"
+
+        # Embed query (check cache first)
+        q_emb = self.cache.get(query)
+        if q_emb is None:
+            q_emb = get_embeddings([query], model=self.embedding_model)[0]
+            self.cache.set(query, q_emb)
+
+        scores = batch_cosine_similarity(q_emb, self._matrix)
+        top_indices = np.argsort(scores)[::-1][:top_k]
+        return [self.tools[i] for i in top_indices]
+
+
+# ---------------------------------------------------------------------------
+# Public factory
+# ---------------------------------------------------------------------------
+
+def create_mcp_rag_optimizer(
+    all_tools: List["Tool"],
+    server: "MCPServer",
+    embedding_model: str = "text-embedding-3-small",
+    top_k: int = _DEFAULT_TOP_K,
+) -> "Tool":
+    """
+    Return a single 'rag_optimizer' Tool that searches the full tool
+    catalogue via embedding similarity and stages the top-K matches
+    in the runtime for the next LLM turn.
+
+    Args:
+        all_tools:        Full catalogue of MCP tools (may exceed 128).
+        embedding_model:  LiteLLM-compatible embedding model name.
+        top_k:            Default number of tools to retrieve.
+
+    Returns:
+        One Tool the orchestrator should send when len(tools) > 128.
+    """
+    from ..tools import Tool, ToolSchema
+
+    index = ToolIndex(tools=all_tools, embedding_model=embedding_model)
+    index.build()  # eager — avoids latency on first LLM call
+
+    tool_name = f"mcp_{server.name}_rag_optimizer"
+
+    server_context = (
+        f" This server provides: {server.config.description}." if getattr(server.config, "description", None)
+        else ""
+    )
+
+    tool_description = (
+        f"Search all available tools from the '{server.name}' MCP server "
+        f"using a list of focused, single-purpose natural-language queries. "
+        f"{server_context}"
+        f"Pass one query per capability you need — results are merged and deduplicated. "
+        f"Call this when you don't know which tool to use. "
+        f"The best matching tools will be injected into your next turn so you can call them directly."
+    )
+
+    # Mutable state shared between execute_rag_optimizer and metadata
+    state: dict = {"retrieved_top_k_tools": []}
+
+    # ------------------------------------------------------------------
+    async def execute_rag_optimizer(arguments: dict, runtime: "Runtime") -> str:
+        raw_queries = arguments.get("queries", [])
+        requested_k: int = int(arguments.get("top_k", top_k))
+
+        queries = [q.strip() for q in raw_queries if isinstance(q, str) and q.strip()]
+        if not queries:
+            return "Error: 'queries' must be a non-empty list of strings."
+
+        requested_k = max(1, min(requested_k, _TOOL_LIMIT))
+
+        # Search per query, then deduplicate preserving best-rank-first order
+        seen: set[str] = set()
+        merged: list = []
+        for q in queries:
+            for tool in index.search(q, top_k=requested_k):
+                if tool.name not in seen:
+                    seen.add(tool.name)
+                    merged.append((q, tool))
+
+        state["retrieved_top_k_tools"] = [t for _, t in merged]
+
+        lines = [
+            f"Found {len(merged)} unique tools across {len(queries)} queries. "
+            "They will be available alongside this tool in your next turn.\n"
+        ]
+        current_q = None
+        for q, t in merged:
+            if q != current_q:
+                lines.append(f"\n[Query: '{q}']")
+                current_q = q
+            lines.append(f"  • {t.name} — {t.description[:120]}")
+
+        return "\n".join(lines)
+
+    schema = ToolSchema(
+        type="object",
+        properties={
+            "queries": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "List of focused, single-purpose queries — one per capability you need. "
+                    "Each query should describe exactly one tool's job. "
+                    "GOOD: ['list open ports on a host', 'get process memory usage'] "
+                    "BAD:  ['list ports and memory and CPU and disk']. "
+                    "More focused queries = higher retrieval accuracy."
+                ),
+            },
+            "top_k": {
+                "type": "integer",
+                "description": (
+                    f"How many tools to retrieve per query (1–{_TOOL_LIMIT}). "
+                    f"Defaults to {top_k}. Total results may be up to queries × top_k (deduplicated)."
+                ),
+            },
+        },
+        required=["queries"],
+    )
+
+    return Tool(
+        name=tool_name,
+        description=tool_description,
+        schema=schema,
+        execute_fn=execute_rag_optimizer,
+        category="meta",
+        metadata={
+            "total_tools_indexed": all_tools,
+            "embedding_model": embedding_model,
+            "default_top_k": top_k,
+            "is_rag_optimizer": True,
+            "top_k_tools": state,
+        },
+    )


### PR DESCRIPTION
When a MCP server with many tools is exposed (>128 tools), so models reject so many tools and the ones that allow them, do not perform very well, and also, the cost of tokens is very high in every query, so, in these cases, a RAG tool is implemented, so that this is the only exposed tool to the agent, the agent query capabilities for the needed tools and the RAG tool will perform RAG and retrieve the appropriated tools. During the following iterations, the tools are available.