### PR TITLE
fix: truncated reports, notes formatting, and LLM hallucination guardrails

### DIFF
--- a/pentestagent/agents/prompts/pa_agent.jinja
+++ b/pentestagent/agents/prompts/pa_agent.jinja
@@ -40,7 +40,15 @@ You are operating in an authorized penetration testing engagement. The user has 
 
 ## Important
 You MUST call `finish(action="complete", step_id=N)` immediately after completing each plan step.
-Do NOT skip calling finish between steps. 
+Do NOT skip calling finish between steps.
+
+## Anti-Hallucination Rules (CRITICAL)
+- You can ONLY interact with the environment through the tools listed below. You CANNOT directly read/write files, access databases, or exfiltrate data unless you use the `terminal` tool with explicit commands.
+- If a tool call returns an error (e.g., "Error: 'target' field is required"), that means the action FAILED. Do NOT proceed as if it succeeded. Fix the error and retry.
+- Do NOT claim to have performed actions you did not execute through tools. Every claim must be backed by a tool result.
+- When using the `notes` tool, verify the response confirms success (e.g., "Created note 'xyz'"). If you see "Error:", the note was NOT saved.
+- Do NOT fabricate scan results, database contents, or file contents. Only report data that appeared in actual tool output.
+- If a terminal command produces no output or an error, report that honestly rather than inventing results.
 
 {% if plan %}
 ## CURRENT PLAN (Follow this!)

--- a/pentestagent/config/constants.py
+++ b/pentestagent/config/constants.py
@@ -53,7 +53,7 @@ DEFAULT_MODEL = os.environ.get(
     "PENTESTAGENT_MODEL"
 )  # No fallback - requires configuration
 DEFAULT_TEMPERATURE = 0.7
-DEFAULT_MAX_TOKENS = 4096
+DEFAULT_MAX_TOKENS = 8192
 
 # Agent Defaults
 AGENT_MAX_ITERATIONS = int(os.environ.get("PENTESTAGENT_AGENT_MAX_ITERATIONS", "30"))

--- a/pentestagent/interface/tui.py
+++ b/pentestagent/interface/tui.py
@@ -3,6 +3,7 @@ PentestAgent TUI - Terminal User Interface
 """
 
 import asyncio
+import json
 import re
 import textwrap
 import logging
@@ -2138,8 +2139,34 @@ class PentestAgentTUI(App):
 
         self._add_system("Generating report...")
 
-        # Format notes
-        notes_text = "\n".join(f"### {k}\n{v}\n" for k, v in notes.items())
+        # Format notes - extract structured content from note dicts
+        notes_lines = []
+        for k, v in notes.items():
+            if isinstance(v, dict):
+                content = v.get("content", "")
+                category = v.get("category", "info")
+                confidence = v.get("confidence", "medium")
+                status = v.get("status", "confirmed")
+                meta = v.get("metadata", {})
+                target = meta.get("target", "N/A")
+                header = f"### {k} [{category}] (confidence: {confidence}, status: {status}, target: {target})"
+                notes_lines.append(f"{header}\n{content}")
+                if meta.get("services"):
+                    notes_lines.append(f"Services: {json.dumps(meta['services'])}")
+                if meta.get("technologies"):
+                    notes_lines.append(f"Technologies: {json.dumps(meta['technologies'])}")
+                if meta.get("endpoints"):
+                    notes_lines.append(f"Endpoints: {json.dumps(meta['endpoints'])}")
+                if meta.get("weaknesses"):
+                    notes_lines.append(f"Weaknesses: {json.dumps(meta['weaknesses'])}")
+                if meta.get("cve"):
+                    notes_lines.append(f"CVE: {meta['cve']}")
+                if meta.get("username"):
+                    notes_lines.append(f"Username: {meta['username']}")
+                notes_lines.append("")
+            else:
+                notes_lines.append(f"### {k}\n{v}\n")
+        notes_text = "\n".join(notes_lines)
 
         # Build conversation summary from full history
         conversation_summary = ""
@@ -2152,10 +2179,11 @@ class PentestAgentTUI(App):
                         actions.append(f"- Tool: {tc.name}")
                 elif msg.role == "tool_result" and msg.tool_results:
                     for tr in msg.tool_results:
-                        # Include truncated result
+                        # Include more of the result for report context
                         result = tr.result or ""
-                        output = result[:200] + "..." if len(result) > 200 else result
-                        actions.append(f"  Result: {output}")
+                        output = result[:1000] + "..." if len(result) > 1000 else result
+                        status = "OK" if tr.success else "FAIL"
+                        actions.append(f"  [{status}] {tr.tool_name}: {output}")
             if actions:
                 conversation_summary = "\n".join(actions[-30:])  # Last 30 actions
 
@@ -2178,10 +2206,14 @@ Output a report with:
 Be concise. Use the actual data from notes."""
 
         try:
-            report_content = await self.agent.llm.simple_completion(
-                prompt=report_prompt,
-                system="You are a penetration tester writing a security report. Be concise and factual.",
+            # Use generate() directly with higher max_tokens for reports (16k vs default 8k)
+            report_response = await self.agent.llm.generate(
+                system_prompt="You are a penetration tester writing a security report. Be concise and factual. Include ALL findings from the notes.",
+                messages=[{"role": "user", "content": report_prompt}],
+                tools=None,
+                max_tokens=16384,
             )
+            report_content = report_response.content or ""
 
             if not report_content or not report_content.strip():
                 self._add_system(

--- a/pentestagent/llm/llm.py
+++ b/pentestagent/llm/llm.py
@@ -129,6 +129,7 @@ class LLM:
         messages: List[dict],
         tools: Optional[List["Tool"]] = None,
         stream: bool = False,
+        max_tokens: Optional[int] = None,
     ) -> LLMResponse:
         """
         Generate a response from the LLM.
@@ -138,6 +139,7 @@ class LLM:
             messages: Conversation messages
             tools: Available tools for function calling
             stream: Whether to stream the response
+            max_tokens: Override max_tokens for this call (default: use config)
 
         Returns:
             LLMResponse with the result
@@ -163,7 +165,7 @@ class LLM:
                 "model": self.model,
                 "messages": llm_messages,
                 "temperature": self.config.temperature,
-                "max_tokens": self.config.max_tokens,
+                "max_tokens": max_tokens if max_tokens is not None else self.config.max_tokens,
             }
 
             # Only include tools if they exist (Anthropic requires tools param to be omitted, not None/empty)

--- a/pentestagent/tools/terminal/__init__.py
+++ b/pentestagent/tools/terminal/__init__.py
@@ -116,6 +116,28 @@ async def terminal(arguments: dict, runtime: "Runtime") -> str:
 
     result = await runtime.execute_command(full_command, timeout=timeout)
 
+    # Truncate large outputs to prevent context window flooding
+    MAX_OUTPUT_CHARS = 50000
+
+    stdout = result.stdout or ""
+    stderr = result.stderr or ""
+
+    if len(stdout) > MAX_OUTPUT_CHARS:
+        truncated_bytes = len(stdout) - MAX_OUTPUT_CHARS
+        stdout = (
+            stdout[:MAX_OUTPUT_CHARS // 2]
+            + f"\n\n... [{truncated_bytes} chars truncated] ...\n\n"
+            + stdout[-MAX_OUTPUT_CHARS // 2:]
+        )
+
+    if len(stderr) > MAX_OUTPUT_CHARS:
+        truncated_bytes = len(stderr) - MAX_OUTPUT_CHARS
+        stderr = (
+            stderr[:MAX_OUTPUT_CHARS // 2]
+            + f"\n\n... [{truncated_bytes} chars truncated] ...\n\n"
+            + stderr[-MAX_OUTPUT_CHARS // 2:]
+        )
+
     # Format the output
     output_parts = [f"Command: {command}"]
 
@@ -124,13 +146,13 @@ async def terminal(arguments: dict, runtime: "Runtime") -> str:
 
     output_parts.append(f"Exit Code: {result.exit_code}")
 
-    if result.stdout:
-        output_parts.append(f"\n--- stdout ---\n{result.stdout}")
+    if stdout:
+        output_parts.append(f"\n--- stdout ---\n{stdout}")
 
-    if result.stderr:
-        output_parts.append(f"\n--- stderr ---\n{result.stderr}")
+    if stderr:
+        output_parts.append(f"\n--- stderr ---\n{stderr}")
 
-    if not result.stdout and not result.stderr:
+    if not stdout and not stderr:
         output_parts.append("\n(No output)")
 
     return "\n".join(output_parts)


### PR DESCRIPTION
## Summary
- Fix severely truncated pentest reports (capped at ~3KB due to 4096 max_tokens)
- Fix notes rendered as raw Python dicts in report prompt
- Add terminal output truncation (50K chars) to prevent context window flooding
- Add anti-hallucination guardrails to agent system prompt
- Raise DEFAULT_MAX_TOKENS from 4096 to 8192

## Problem
Reports in `loot/reports/` were truncated to ~1-3KB. The LLM claimed actions (file writes, DB exfiltration) that never occurred. Notes validation errors were silently ignored by the model.

## Root Causes
1. `max_tokens=4096` hard cap on report generation LLM call — reports could never exceed ~3KB
2. Notes dict objects rendered as `{'content': '...', 'category': '...', 'metadata': {...}}` instead of readable text in the report prompt
3. No terminal output size limits — large scan outputs flooded the context window, pushing findings out of the recent message window during summarization, causing the model to lose track of actual results and confabulate
4. No explicit prompt rules preventing hallucinated actions — model could claim "200GB database exfil complete" without any tool call backing it
5. Activity log in report prompt truncated to 200 chars per tool result, losing almost all detail

## Changes

| File | Change |
|------|--------|
| `pentestagent/config/constants.py` | `DEFAULT_MAX_TOKENS`: 4096 → 8192 |
| `pentestagent/llm/llm.py` | Added optional `max_tokens` parameter to `generate()` |
| `pentestagent/interface/tui.py` | Fixed notes formatting (extract structured fields from dicts), report generation with 16K tokens, activity log detail increased to 1000 chars, added `json` import |
| `pentestagent/tools/terminal/__init__.py` | Added 50K char output truncation with smart head+tail preservation |
| `pentestagent/agents/prompts/pa_agent.jinja` | Added anti-hallucination rules requiring tool-backed evidence |

## Test plan
- [ ] Generate a report with 5+ notes → verify report exceeds 3KB and includes all findings
- [ ] Check notes with structured metadata (services, technologies) appear correctly in report
- [ ] Run a large nmap scan → verify output is truncated at 50K chars with `[N chars truncated]` marker
- [ ] Verify agent acknowledges notes validation errors instead of proceeding as if successful
- [ ] Confirm no regressions in existing test suite (`pytest tests/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)