### PR TITLE
feat: hierarchical multi-agent TUI with embedded terminals and FIFO transport

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,22 @@
       "type": "python",
       "request": "launch",
       "module": "pentestagent",
-      "cwd": "/app",
+      "cwd": "/home/fernando/pentestagent/",
+      "console": "integratedTerminal",
+      "justMyCode": true
+    },
+    {
+      "name": "MCP Server + TUI (SSE)",
+      "type": "python",
+      "request": "launch",
+      "module": "pentestagent",
+      "args": [
+        "mcp_server",
+        "--type", "sse",
+        "--tui",
+        "--port", "8080"
+      ],
+      "cwd": "/home/fernando/pentestagent/",
       "console": "integratedTerminal",
       "justMyCode": true
     }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "type": "python",
       "request": "launch",
       "module": "pentestagent",
-      "cwd": "/home/fernando/pentestagent/",
+      "cwd": "/app",
       "console": "integratedTerminal",
       "justMyCode": true
     },
@@ -21,7 +21,7 @@
         "--tui",
         "--port", "8080"
       ],
-      "cwd": "/home/fernando/pentestagent/",
+      "cwd": "/app",
       "console": "integratedTerminal",
       "justMyCode": true
     }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,224 @@
+# PentestAgent — CLAUDE.md
+
+## Project overview
+
+**PentestAgent** (v0.2.0) is an AI-powered penetration testing framework built in Python.
+It wraps LiteLLM to support any provider (Anthropic, OpenAI, etc.) and exposes a TUI,
+a CLI, and an MCP server interface. The agent can run tools locally or inside a Docker
+sandbox (base or Kali image).
+
+## Tech stack
+
+- **Python 3.10+**, packaged with Hatchling (`pyproject.toml`)
+- **LiteLLM** — provider-agnostic LLM wrapper
+- **Textual** — TUI framework (`pentestagent/interface/`)
+- **Typer** — CLI framework
+- **Playwright** — browser tool
+- **MCP (Model Context Protocol)** — both client (consuming external servers) and server
+  (exposing PentestAgent to Claude Desktop / Cursor / etc.)
+- **FAISS + sentence-transformers** — optional RAG engine (`pip install -e ".[rag]"`)
+
+## Repository layout
+
+```
+pentestagent/
+  agents/
+    crew/           # Multi-agent mode: orchestrator + worker pool + shadow graph
+    pa_agent/       # Single-agent implementation
+    state.py        # Shared agent state
+  config/
+    settings.py     # Global Settings dataclass (singleton via get_settings())
+    constants.py    # Model defaults, iteration limits, etc.
+  interface/
+    cli.py          # Typer CLI entry-point
+    notifier.py     # Event bus between agent and UI
+    utils.py        # Shared UI helpers
+  knowledge/
+    graph.py        # ShadowGraph — derives strategic insights from notes
+    indexer.py      # Indexes knowledge sources for RAG
+    rag.py          # FAISS-backed retrieval
+  llm/
+    config.py       # LiteLLM configuration
+    memory.py       # Conversation/token management
+    utils.py        # Streaming helpers
+  mcp/
+    stdio_adapter.py    # STDIO MCP server transport
+    example_adapter.py  # SSE MCP server transport
+  playbooks/
+    base_playbook.py
+    thp3_recon.py / thp3_network.py / thp3_web.py
+  runtime/
+    docker_runtime.py   # Runs tool commands inside Docker
+    tool_server.py      # Local runtime
+  tools/
+    loader.py       # Discovers & dynamically imports tool modules
+    executor.py     # Executes tool calls, tracks tokens
+    token_tracker.py
+    terminal/       # Shell execution tool
+    browser/        # Playwright browser tool
+    web_search/     # Tavily web search (needs TAVILY_API_KEY)
+    notes/          # Persistent findings store → loot/notes.json
+    finish/         # Signals task completion
+  workspaces/       # Workspace isolation helpers
+loot/               # Persisted notes and findings (git-ignored)
+mcp_examples/       # Example MCP configs and adapters
+scripts/            # setup.sh / setup.ps1
+tests/              # pytest suite
+```
+
+## Configuration
+
+Create `.env` in the project root:
+
+```
+ANTHROPIC_API_KEY=sk-ant-...
+PENTESTAGENT_MODEL=claude-sonnet-4-20250514
+
+# Optional
+TAVILY_API_KEY=...          # web_search tool
+OPENAI_API_KEY=sk-...       # if using OpenAI
+```
+
+Settings are managed by `pentestagent/config/settings.py` (`get_settings()` singleton).
+The MCP external-server config lives in `mcp_servers.json` (Claude Desktop format).
+
+## Running the project
+
+```bash
+source venv/bin/activate
+pentestagent                    # TUI
+pentestagent -t 192.168.1.1     # TUI with pre-set target
+pentestagent --docker           # Use Docker sandbox for tool execution
+pentestagent run -t example.com --playbook thp3_web   # Run a playbook
+pentestagent mcp_server --type stdio   # Expose as MCP server (STDIO)
+pentestagent mcp_server --type sse     # Expose as MCP server (HTTP/SSE, port 8080)
+```
+
+## PentestAgent as MCP server
+
+PentestAgent can expose itself as an MCP server so any MCP-compatible client
+(Claude Desktop, Cursor, etc.) can drive it programmatically.
+
+### Transports
+
+```bash
+# STDIO — for local clients
+pentestagent mcp_server --type stdio
+pentestagent mcp_server --type stdio --target 192.168.1.1 --scope 192.168.1.0/24 --docker
+
+# SSE (HTTP) — for remote/networked clients (default: 0.0.0.0:8080)
+pentestagent mcp_server --type sse
+pentestagent mcp_server --type sse --host 0.0.0.0 --port 8080 --target 10.0.0.1
+```
+
+### Claude Desktop config (`claude_desktop_config.json`)
+
+```json
+{
+  "mcpServers": {
+    "pentestagent": {
+      "command": "pentestagent",
+      "args": ["mcp_server", "--type", "stdio"]
+    }
+  }
+}
+```
+
+### Tools exposed by the MCP server
+
+| Category | Tools |
+|----------|-------|
+| Status / config | `get_server_status`, `get_config`, `update_config` |
+| Task execution | `run_task` (blocking), `run_task_async` (returns task_id) |
+| Task inspection | `list_tasks`, `get_task_status`, `get_task_result`, `await_tasks` |
+| Task control | `cancel_task` |
+| Tool management | `list_tools`, `enable_tool`, `disable_tool` |
+| Conversation | `get_conversation_history`, `reset_conversation` |
+| Memory | `store_memory`, `retrieve_memory`, `clear_memory` |
+| Observability | `get_logs`, `get_metrics` |
+
+### Async task pattern
+
+```
+run_task_async  task="Enumerate subdomains of example.com"
+run_task_async  task="Run nmap SYN scan on example.com"
+await_tasks     task_ids=["<id1>", "<id2>"]  timeout_seconds=300
+get_task_result task_id="<id1>"
+get_task_result task_id="<id2>"
+```
+
+### `mcp_server` flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--type` | *(required)* | `stdio` or `sse` |
+| `--host` | `0.0.0.0` | SSE bind host |
+| `--port` | `8080` | SSE bind port |
+| `--target` | none | Primary pentest target |
+| `--scope` | `[]` | In-scope CIDRs (space-separated) |
+| `--model` | env var | Overrides `PENTESTAGENT_MODEL` |
+| `--docker` | false | Use DockerRuntime |
+| `--no-rag` | false | Skip RAG initialisation |
+| `--no-mcp` | false | Skip external MCP connections |
+
+---
+
+## TUI commands (quick reference)
+
+| Command | Description |
+|---------|-------------|
+| `/assist <task>` | Single-shot instruction with tool execution |
+| `/agent <task>` | Autonomous single-agent loop |
+| `/crew <task>` | Multi-agent: orchestrator spawns specialised workers |
+| `/interact <task>` | Guided interactive chat |
+| `/target <host>` | Set target |
+| `/tools` | List available tools |
+| `/notes` | Show saved findings |
+| `/report` | Generate report from session |
+| `/mcp list/add` | Manage MCP servers |
+| `Esc` | Stop running agent |
+
+## Key architectural patterns
+
+- **Tool registration**: Tools self-register via `pentestagent/tools/loader.py`. Add a new
+  tool by creating a directory under `pentestagent/tools/<name>/` with an `__init__.py`
+  that registers it with the tool registry.
+- **Modes**: assist → single LLM call; agent → agentic loop; crew → `CrewOrchestrator`
+  manages a `WorkerPool`; interact → streaming chat.
+- **MCP server tools**: `run_task`, `run_task_async`, `await_tasks`, `get_task_result`,
+  `list_tasks`, `cancel_task`, `list_tools`, `enable_tool`, `disable_tool`, `store_memory`,
+  `retrieve_memory`, `get_logs`, `get_metrics`.
+- **Agent self-spawning** (`spawn_mcp_agent`): running agent can spawn child agents as
+  MCP servers over stdio, enabling hierarchical multi-agent workflows.
+- **RAG tool optimizer**: if an MCP server exposes >128 tools, a single
+  `mcp_<server>_rag_optimizer` meta-tool replaces them and retrieves relevant subsets via
+  embedding similarity.
+- **Notes persistence**: findings saved to `loot/notes.json` via the `notes` tool;
+  categories: `credential`, `vulnerability`, `finding`, `artifact`.
+- **ShadowGraph** (crew mode only): builds a knowledge graph from notes to provide
+  strategic context to the orchestrator.
+
+## Development
+
+```bash
+pip install -e ".[dev]"
+pytest                       # Run tests
+pytest --cov=pentestagent    # With coverage
+black pentestagent           # Format
+ruff check pentestagent      # Lint
+```
+
+Test config: `pytest.ini_options` in `pyproject.toml`, asyncio mode = auto.
+
+## Docker
+
+```bash
+docker compose build
+docker compose run --rm pentestagent          # Base image
+docker compose --profile kali run --rm pentestagent-kali   # Kali image
+```
+
+## Legal
+
+Only use against systems you have **explicit written authorisation** to test.
+Unauthorised access is illegal. MIT licence.

--- a/pentestagent/agents/base_agent.py
+++ b/pentestagent/agents/base_agent.py
@@ -1146,6 +1146,13 @@ Call create_plan with the new steps OR feasible=False."""
                 tools=mcp_tools + self.suggested_tools,
             )
     
+            # ── finish_reason: break early if LLM signals done or context full ──
+            finish_reason = getattr(response, 'finish_reason', None)
+            if finish_reason == 'length':
+                break
+            elif finish_reason == 'stop' and not response.tool_calls:
+                pass
+
             # ── Empty response ────────────────────────────────────────────────
             if not response.tool_calls and not response.content:
                 empty_msg = AgentMessage(
@@ -1164,7 +1171,7 @@ Call create_plan with the new steps OR feasible=False."""
             if not response.tool_calls:
                 final_msg = AgentMessage(
                     role="assistant",
-                    content=response.content,
+                    content=response.content or "",
                     usage=response.usage,
                     metadata={"task_complete": True},
                 )
@@ -1235,7 +1242,7 @@ Call create_plan with the new steps OR feasible=False."""
             )
     
             self.state_manager.transition_to(AgentState.THINKING)
-    
+
         # ── Max iterations reached ────────────────────────────────────────────
         # Ask the LLM for a partial-results summary before stopping
         try:
@@ -1246,7 +1253,7 @@ Call create_plan with the new steps OR feasible=False."""
                     "Summarize what was accomplished and what remains."
                 ),
                 messages=self._format_messages_for_llm(),
-                tools=mcp_tools,
+                tools=[],  # No tools — we need text output, not tool calls
             )
             summary_content = summary_response.content or "Max iterations reached — no summary available."
         except Exception:

--- a/pentestagent/interface/initializer.py
+++ b/pentestagent/interface/initializer.py
@@ -1,0 +1,175 @@
+"""Shared agent component initialization logic.
+
+Used by both the TUI and the MCP server so the startup sequence is defined
+in exactly one place.  Callers supply an optional *on_progress* callback
+that receives ``(level: str, message: str)`` notifications; if omitted the
+messages are silently discarded.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+
+async def build_agent_components(
+    target: Optional[str] = None,
+    scope: Optional[list[str]] = None,
+    model: Optional[str] = None,
+    docker: bool = False,
+    no_rag: bool = False,
+    no_mcp: bool = False,
+    on_progress: Optional[Callable[[str, str], None]] = None,
+    after_mcp_load: Optional[Callable[[], None]] = None,
+) -> dict[str, Any]:
+    """Build every shared agent component in the standard order.
+
+    Returns a dict with keys:
+        ``agent``           – PentestAgentAgent instance
+        ``runtime``         – DockerRuntime or LocalRuntime
+        ``rag_engine``      – RAGEngine (or None)
+        ``all_tools``       – list of all registered Tool objects
+        ``mcp_manager``     – MCPManager (or None)
+        ``rag_doc_count``   – int
+        ``mcp_server_count``– int
+        ``model``           – resolved model string
+    """
+    from ..agents.pa_agent import PentestAgentAgent
+    from ..knowledge import RAGEngine
+    from ..llm import LLM, ModelConfig
+    from ..tools import get_all_tools, register_tool_instance
+
+    scope = list(scope or [])
+
+    def _log(msg: str, level: str = "info") -> None:
+        if on_progress:
+            on_progress(level, msg)
+
+    # ------------------------------------------------------------------
+    # 1. RAG Engine
+    # ------------------------------------------------------------------
+    rag_engine: Optional[RAGEngine] = None
+    rag_doc_count = 0
+
+    if not no_rag:
+        local_knowledge = Path("knowledge")
+        bundled_path = Path(__file__).parent.parent / "knowledge" / "sources"
+        knowledge_path: Optional[Path] = None
+
+        if local_knowledge.exists() and any(local_knowledge.rglob("*.*")):
+            knowledge_path = local_knowledge
+        elif bundled_path.exists():
+            knowledge_path = bundled_path
+
+        if knowledge_path:
+            try:
+                embeddings_setting = os.getenv("PENTESTAGENT_EMBEDDINGS", "").lower()
+                if embeddings_setting == "local":
+                    use_local = True
+                elif embeddings_setting == "openai":
+                    use_local = False
+                else:
+                    use_local = not os.getenv("OPENAI_API_KEY")
+
+                rag_engine = RAGEngine(
+                    knowledge_path=knowledge_path,
+                    use_local_embeddings=use_local,
+                )
+                await asyncio.to_thread(rag_engine.index)
+                rag_doc_count = rag_engine.get_document_count()
+                _log(f"RAG engine ready — {rag_doc_count} documents indexed.")
+            except Exception as exc:
+                _log(f"RAG engine failed, continuing without it: {exc}", "warning")
+                rag_engine = None
+
+    # ------------------------------------------------------------------
+    # 2. Runtime
+    # ------------------------------------------------------------------
+    if docker:
+        from ..runtime.docker_runtime import DockerRuntime
+        runtime: Any = DockerRuntime()
+        _log("Using DockerRuntime.")
+    else:
+        from ..runtime.runtime import LocalRuntime
+        runtime = LocalRuntime()
+        _log("Using LocalRuntime.")
+
+    await runtime.start()
+
+    # ------------------------------------------------------------------
+    # 3. Model / LLM
+    # ------------------------------------------------------------------
+    if not model:
+        model = os.getenv("PENTESTAGENT_MODEL")
+    if not model:
+        raise RuntimeError(
+            "No model configured. Pass --model or set PENTESTAGENT_MODEL."
+        )
+
+    llm = LLM(
+        model=model,
+        config=ModelConfig(temperature=0.7),
+        rag_engine=rag_engine,
+    )
+    _log(f"LLM initialised: {model}")
+
+    # ------------------------------------------------------------------
+    # 4. Tools
+    # ------------------------------------------------------------------
+    all_tools = get_all_tools()
+    _log(f"Built-in tools loaded: {len(all_tools)}")
+
+    # ------------------------------------------------------------------
+    # 5. Primary PentestAgentAgent
+    # ------------------------------------------------------------------
+    agent = PentestAgentAgent(
+        llm=llm,
+        tools=all_tools,
+        runtime=runtime,
+        target=target,
+        scope=scope,
+        rag_engine=rag_engine,
+    )
+    _log(f"PentestAgentAgent ready — target={target} scope={scope}")
+
+    # ------------------------------------------------------------------
+    # 6. External MCP servers (background task)
+    # ------------------------------------------------------------------
+    mcp_manager = None
+    mcp_server_count = 0
+
+    if not no_mcp:
+        try:
+            from ..mcp import MCPManager
+
+            mcp_manager = MCPManager()
+            mcp_server_count = len(mcp_manager.list_configured_servers())
+
+            async def _load_mcp() -> None:
+                try:
+                    tools = await mcp_manager.connect_all()
+                    agent.add_tools(tools)
+                    for tool in tools:
+                        register_tool_instance(tool)
+                    _log(f"External MCP tools loaded: {len(tools)}")
+                    if after_mcp_load:
+                        after_mcp_load()
+                except Exception as exc:
+                    _log(f"External MCP connect failed: {exc}", "warning")
+
+            asyncio.get_event_loop().create_task(_load_mcp())
+            _log(f"External MCP servers: {mcp_server_count} configured.")
+        except Exception as exc:
+            _log(f"MCPManager unavailable: {exc}", "warning")
+
+    return {
+        "agent": agent,
+        "runtime": runtime,
+        "rag_engine": rag_engine,
+        "all_tools": all_tools,
+        "mcp_manager": mcp_manager,
+        "rag_doc_count": rag_doc_count,
+        "mcp_server_count": mcp_server_count,
+        "model": model,
+    }

--- a/pentestagent/interface/main.py
+++ b/pentestagent/interface/main.py
@@ -132,7 +132,22 @@ Examples:
     mcp_server_parser.add_argument("--no-mcp", action="store_true", help="Skip external MCP server connections")
     mcp_server_parser.add_argument(
         "--tui", action="store_true",
-        help="Launch TUI observation panel alongside the MCP server (SSE only)"
+        help=(
+            "Launch TUI observation panel alongside the MCP server. "
+            "With --type sse the TUI runs in the same process. "
+            "With --type stdio, requires --mcp-fifo-in/out so that MCP I/O "
+            "uses named pipes instead of stdin/stdout (leaving the PTY free for the TUI)."
+        ),
+    )
+    mcp_server_parser.add_argument(
+        "--mcp-fifo-in", default=None, dest="mcp_fifo_in",
+        help="Named FIFO path for incoming MCP requests (parent→child). "
+             "Required when --type stdio --tui is used.",
+    )
+    mcp_server_parser.add_argument(
+        "--mcp-fifo-out", default=None, dest="mcp_fifo_out",
+        help="Named FIFO path for outgoing MCP responses (child→parent). "
+             "Required when --type stdio --tui is used.",
     )
 
 
@@ -791,10 +806,16 @@ def start_mcp_server(args: argparse.Namespace) -> None:
     console = Console(stderr=True)
 
     if getattr(args, "tui", False):
-        if args.type != "sse":
-            console.print("[red]--tui requires --type sse (stdio transport takes over stdin/stdout)[/red]")
+        if args.type == "sse":
+            asyncio.run(_run_mcp_with_tui(args))
             return
-        asyncio.run(_run_mcp_with_tui(args))
+        # stdio + tui: requires named FIFOs so that the PTY is free for the TUI
+        if not getattr(args, "mcp_fifo_in", None) or not getattr(args, "mcp_fifo_out", None):
+            console.print(
+                "[red]--tui with --type stdio requires --mcp-fifo-in and --mcp-fifo-out[/red]"
+            )
+            return
+        asyncio.run(_run_stdio_tui_fifo(args))
         return
 
     async def _run_stdio() -> None:
@@ -814,6 +835,39 @@ def start_mcp_server(args: argparse.Namespace) -> None:
         asyncio.run(_run_stdio())
     else:
         asyncio.run(_run_streamable_http())
+
+
+async def _run_stdio_tui_fifo(args: argparse.Namespace) -> None:
+    """Launch MCP STDIO server over named FIFOs *and* the TUI in the same process.
+
+    The FIFOs decouple MCP I/O from the terminal's PTY, so Textual can use the
+    PTY normally while the parent agent communicates via the pipe pair.
+    """
+    from ..mcp.server import MCPRouter, mcp_tool_registry, mcp_transport_stdio
+    from ..mcp.server.mcp_tools import set_ui_hook
+    from .tui import PentestAgentTUI
+
+    components = await _initialize(args)
+
+    app = PentestAgentTUI(
+        mcp_mode=True,
+        prebuilt_components=components,
+    )
+    set_ui_hook(app.on_mcp_event)
+
+    router = MCPRouter(mcp_tool_registry)
+    fifo_task = asyncio.create_task(
+        mcp_transport_stdio.run_stdio_fifo(router, args.mcp_fifo_in, args.mcp_fifo_out)
+    )
+
+    try:
+        await app.run_async()
+    finally:
+        fifo_task.cancel()
+        try:
+            await fifo_task
+        except (asyncio.CancelledError, Exception):
+            pass
 
 
 async def _run_mcp_with_tui(args: argparse.Namespace) -> None:

--- a/pentestagent/interface/main.py
+++ b/pentestagent/interface/main.py
@@ -130,6 +130,10 @@ Examples:
                         help="Use DockerRuntime instead of LocalRuntime")
     mcp_server_parser.add_argument("--no-rag", action="store_true", help="Skip RAG engine initialisation")
     mcp_server_parser.add_argument("--no-mcp", action="store_true", help="Skip external MCP server connections")
+    mcp_server_parser.add_argument(
+        "--tui", action="store_true",
+        help="Launch TUI observation panel alongside the MCP server (SSE only)"
+    )
 
 
     # MCP subcommand
@@ -714,118 +718,45 @@ def handle_mcp_command(args: argparse.Namespace):
     else:
         console.print("[yellow]Use 'pentestagent mcp --help' for available commands[/]")
 
-async def _initialize(args: argparse.Namespace):
+async def _initialize(args: argparse.Namespace) -> dict:
     """
-    Build every component in the same order as the TUI does, then hand the
-    fully-constructed PentestAgentAgent to mcp_tools.bootstrap().
+    Build every component via the shared initializer, then bootstrap the
+    MCP tools registry.  Returns the full components dict so callers have
+    access to runtime, rag_engine, etc.
     """
-    import os
- 
     from rich.console import Console
- 
-    from ..agents.pa_agent import PentestAgentAgent
-    from pentestagent.knowledge import RAGEngine
-    from pentestagent.llm import LLM, ModelConfig
-    from pentestagent.tools import get_all_tools, register_tool_instance
- 
-    console = Console(stderr=True)
- 
-    # ------------------------------------------------------------------
-    # 1. RAG Engine  (same path-resolution logic as the TUI)
-    # ------------------------------------------------------------------
-    rag_engine    = None
-    rag_doc_count = 0
- 
-    if not args.no_rag:
-        knowledge_path  = None
-        local_knowledge = Path("knowledge")
-        bundled_path    = Path(__file__).parent.parent / "knowledge" / "sources"
- 
-        if local_knowledge.exists() and any(local_knowledge.rglob("*.*")):
-            knowledge_path = local_knowledge
-        elif bundled_path.exists():
-            knowledge_path = bundled_path
- 
-        if knowledge_path:
-            try:
-                embeddings_setting = os.getenv("PENTESTAGENT_EMBEDDINGS", "").lower()
-                if embeddings_setting == "local":
-                    use_local = True
-                elif embeddings_setting == "openai":
-                    use_local = False
-                else:
-                    use_local = not os.getenv("OPENAI_API_KEY")
- 
-                rag_engine = RAGEngine(
-                    knowledge_path=knowledge_path,
-                    use_local_embeddings=use_local,
-                )
-                await asyncio.to_thread(rag_engine.index)
-                rag_doc_count = rag_engine.get_document_count()
-                console.print(f"RAG engine ready — {rag_doc_count} documents indexed.")
-            except Exception as exc:
-                console.print(f"[yellow]RAG engine failed, continuing without it: {exc}[/yellow]")
-                rag_engine = None
- 
-    # ------------------------------------------------------------------
-    # 2. Runtime  (Docker or Local)
-    # ------------------------------------------------------------------
-    if args.docker:
-        from pentestagent.runtime.docker_runtime import DockerRuntime
-        runtime = DockerRuntime()
-        console.print("Using DockerRuntime.")
-    else:
-        from pentestagent.runtime.runtime import LocalRuntime
-        runtime = LocalRuntime()
-        console.print("Using LocalRuntime.")
- 
-    await runtime.start()
- 
-    # ------------------------------------------------------------------
-    # 3. Model / LLM
-    # ------------------------------------------------------------------
-    model = args.model or os.getenv("PENTESTAGENT_MODEL")
-    if not model:
-        raise RuntimeError(
-            "No model configured. Pass --model or set PENTESTAGENT_MODEL."
-        )
- 
-    llm = LLM(
-        model=model,
-        config=ModelConfig(temperature=0.7),
-        rag_engine=rag_engine,
-    )
-    console.print(f"LLM initialised: {model}")
- 
-    # ------------------------------------------------------------------
-    # 4. Tools
-    # ------------------------------------------------------------------
-    all_tools = get_all_tools()
-    console.print(f"Built-in tools loaded: {len(all_tools)}")
- 
-    # ------------------------------------------------------------------
-    # 5. Primary PentestAgentAgent
-    # ------------------------------------------------------------------
-    agent = PentestAgentAgent(
-        llm=llm,
-        tools=all_tools,
-        runtime=runtime,
-        target=args.target or None,
-        scope=list(args.scope),
-        rag_engine=rag_engine,
-    )
-    console.print(f"PentestAgentAgent ready — target={args.target} scope={args.scope}")
- 
-    # ------------------------------------------------------------------
-    # 6. Bootstrap MCP tools registry  (inject agent + factories)
-    # ------------------------------------------------------------------
+    from ..llm import LLM, ModelConfig
     from ..mcp.server import bootstrap
- 
-    RuntimeClass = type(runtime)
+    from .initializer import build_agent_components
+
+    console = Console(stderr=True)
+
+    def _on_progress(level: str, msg: str) -> None:
+        if level == "warning":
+            console.print(f"[yellow]{msg}[/yellow]")
+        else:
+            console.print(msg)
+
+    components = await build_agent_components(
+        target   = args.target or None,
+        scope    = list(args.scope),
+        model    = args.model or None,
+        docker   = args.docker,
+        no_rag   = args.no_rag,
+        no_mcp   = args.no_mcp,
+        on_progress = _on_progress,
+    )
+
+    agent   = components["agent"]
+    runtime = components["runtime"]
+    model   = components["model"]
+
+    # Bootstrap the MCP tool registry so run_task / run_task_async work.
+    RuntimeClass   = type(runtime)
     llm_kwargs     = {"model": model, "config": ModelConfig(temperature=0.7),
-                      "rag_engine": rag_engine}
-    runtime_kwargs: dict[str, object] = {}
- 
+                      "rag_engine": components["rag_engine"]}
+    runtime_kwargs: dict = {}
+
     bootstrap(
         primary_agent  = agent,
         llm_class      = LLM,
@@ -834,77 +765,89 @@ async def _initialize(args: argparse.Namespace):
         runtime_kwargs = runtime_kwargs,
     )
     console.print("mcp_tools registry bootstrapped.")
- 
-    # ------------------------------------------------------------------
-    # 7. External MCP servers  (background task, same as TUI's load_mcp)
-    # ------------------------------------------------------------------
-    mcp_server_count = 0
- 
-    if not args.no_mcp:
-        try:
-            from pentestagent.mcp import MCPManager
- 
-            mcp_manager      = MCPManager()
-            mcp_server_count = len(mcp_manager.list_configured_servers())
- 
-            async def _load_mcp() -> None:
-                try:
-                    tools = await mcp_manager.connect_all()
-                    agent.add_tools(tools)
-                    for tool in tools:
-                        register_tool_instance(tool)
-                    console.print(f"External MCP tools loaded: {len(tools)}")
-                except Exception as exc:
-                    console.print(f"[yellow]External MCP connect failed: {exc}[/yellow]")
- 
-            asyncio.get_event_loop().create_task(_load_mcp())
-            console.print(f"External MCP servers: {mcp_server_count} configured.")
- 
-        except Exception as exc:
-            console.print(f"[yellow]MCPManager unavailable: {exc}[/yellow]")
- 
-    # ------------------------------------------------------------------
-    # Summary
-    # ------------------------------------------------------------------
+
     console.print(
-        f"Startup complete | model={model} tools={len(all_tools)} "
-        f"mcp_servers={mcp_server_count} rag_docs={rag_doc_count} "
+        f"Startup complete | model={model} "
+        f"tools={len(components['all_tools'])} "
+        f"mcp_servers={components['mcp_server_count']} "
+        f"rag_docs={components['rag_doc_count']} "
         f"runtime={type(runtime).__name__}"
     )
- 
-    return agent
+
+    return components
  
  
 def start_mcp_server(args: argparse.Namespace) -> None:
     """
     Initialise PentestAgent and serve MCP requests over stdio or SSE.
-    Mirrors the TUI startup sequence so both interfaces share identical
-    component construction.
+    When ``args.tui`` is True (SSE-only), also launches the TUI in
+    MCP observation mode so an operator can watch tasks live.
     """
     from aiohttp import web
     from rich.console import Console
- 
+
     from ..mcp.server import MCPRouter, mcp_tool_registry, mcp_transport_stdio
- 
+
     console = Console(stderr=True)
- 
+
+    if getattr(args, "tui", False):
+        if args.type != "sse":
+            console.print("[red]--tui requires --type sse (stdio transport takes over stdin/stdout)[/red]")
+            return
+        asyncio.run(_run_mcp_with_tui(args))
+        return
+
     async def _run_stdio() -> None:
         await _initialize(args)
         router = MCPRouter(mcp_tool_registry)
         console.print("Serving over stdio.")
         await mcp_transport_stdio.run_stdio(router)
- 
+
     async def _run_streamable_http() -> None:
         await _initialize(args)
         router = MCPRouter(mcp_tool_registry)
         app    = mcp_transport_streamable_http.create_streamable_http_app(router)
         console.print(f"Serving SSE on {args.host}:{args.port}")
         await web._run_app(app, host=args.host, port=args.port)
- 
+
     if args.type == "stdio":
         asyncio.run(_run_stdio())
     else:
         asyncio.run(_run_streamable_http())
+
+
+async def _run_mcp_with_tui(args: argparse.Namespace) -> None:
+    """Launch the MCP SSE server and the TUI observation panel together."""
+    from aiohttp import web
+
+    from ..mcp.server import MCPRouter, mcp_tool_registry
+    from ..mcp.server.mcp_tools import set_ui_hook
+    from .tui import PentestAgentTUI
+
+    # Build all components first (before starting the TUI).
+    components = await _initialize(args)
+
+    # Create the TUI in MCP observation mode with the pre-built agent.
+    app = PentestAgentTUI(
+        mcp_mode=True,
+        prebuilt_components=components,
+    )
+
+    # Wire MCP task events to the TUI.
+    set_ui_hook(app.on_mcp_event)
+
+    # Build the SSE server but run it as an asyncio task alongside the TUI.
+    router     = MCPRouter(mcp_tool_registry)
+    aiohttp_app = mcp_transport_streamable_http.create_streamable_http_app(router)
+    runner     = web.AppRunner(aiohttp_app)
+    await runner.setup()
+    site       = web.TCPSite(runner, args.host, args.port)
+    await site.start()
+
+    try:
+        await app.run_async()
+    finally:
+        await runner.cleanup()
         
 
 def handle_workspace_command(args: argparse.Namespace):

--- a/pentestagent/interface/notifier.py
+++ b/pentestagent/interface/notifier.py
@@ -8,12 +8,16 @@ notifications are logged.
 A second channel — `spawn_terminal` / `register_spawn_terminal_callback` —
 lets agent code request that the TUI open an EmbeddedTerminal widget for a
 child agent's PTY output.
+
+A third channel — `despawn_terminal` / `register_despawn_terminal_callback` —
+lets agent code request that the TUI remove a previously opened terminal.
 """
 import logging
 from typing import Callable, Optional
 
 _callback: Optional[Callable[[str, str], None]] = None
 _spawn_terminal_cb: Optional[Callable[[int, str], None]] = None
+_despawn_terminal_cb: Optional[Callable[[str], None]] = None
 
 
 def register_callback(cb: Callable[[str, str], None]) -> None:
@@ -68,3 +72,22 @@ def spawn_terminal(master_fd: int, label: str) -> bool:
         except Exception:
             logging.getLogger(__name__).exception("spawn_terminal callback failed")
     return False
+
+
+def register_despawn_terminal_callback(cb: Callable[[str], None]) -> None:
+    """Register a callback so the TUI can remove a CollapsibleTerminal widget.
+
+    Callback receives (label,).
+    """
+    global _despawn_terminal_cb
+    _despawn_terminal_cb = cb
+
+
+def despawn_terminal(label: str) -> None:
+    """Ask the TUI to close and remove the terminal identified by *label*."""
+    global _despawn_terminal_cb
+    if _despawn_terminal_cb:
+        try:
+            _despawn_terminal_cb(label)
+        except Exception:
+            logging.getLogger(__name__).exception("despawn_terminal callback failed")

--- a/pentestagent/interface/notifier.py
+++ b/pentestagent/interface/notifier.py
@@ -4,11 +4,16 @@ Modules can call `notify(level, message)` to emit operator-visible
 notifications. A UI (TUI) may register a callback via `register_callback()`
 to receive notifications and display them. If no callback is registered,
 notifications are logged.
+
+A second channel — `spawn_terminal` / `register_spawn_terminal_callback` —
+lets agent code request that the TUI open an EmbeddedTerminal widget for a
+child agent's PTY output.
 """
 import logging
 from typing import Callable, Optional
 
 _callback: Optional[Callable[[str, str], None]] = None
+_spawn_terminal_cb: Optional[Callable[[int, str], None]] = None
 
 
 def register_callback(cb: Callable[[str, str], None]) -> None:
@@ -38,3 +43,28 @@ def notify(level: str, message: str) -> None:
         log.warning(message)
     else:
         log.info(message)
+
+
+def register_spawn_terminal_callback(cb: Callable[[int, str], None]) -> None:
+    """Register a callback so the TUI can create an EmbeddedTerminal widget.
+
+    Callback receives (master_fd, label).
+    """
+    global _spawn_terminal_cb
+    _spawn_terminal_cb = cb
+
+
+def spawn_terminal(master_fd: int, label: str) -> bool:
+    """Ask the TUI to open an EmbeddedTerminal for *master_fd*.
+
+    Returns True if the TUI accepted the request, False if no TUI is active
+    (caller should fall back to opening a new terminal window).
+    """
+    global _spawn_terminal_cb
+    if _spawn_terminal_cb:
+        try:
+            _spawn_terminal_cb(master_fd, label)
+            return True
+        except Exception:
+            logging.getLogger(__name__).exception("spawn_terminal callback failed")
+    return False

--- a/pentestagent/interface/tui.py
+++ b/pentestagent/interface/tui.py
@@ -1793,8 +1793,8 @@ class PentestAgentTUI(App):
             except Exception:
                 pass
             try:
-                prompt = self.query_one("#chat-prompt")
-                prompt.update("[dim]obs[/] ")
+                prompt = self.query_one("#chat-prompt", Static)
+                prompt.update("")
             except Exception:
                 pass
             try:

--- a/pentestagent/interface/tui.py
+++ b/pentestagent/interface/tui.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 import pyperclip
 
 from rich.text import Text
-from textual import on, work
+from textual import events, on, work
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import (
@@ -27,6 +27,7 @@ from textual.reactive import reactive
 from textual.screen import ModalScreen
 from textual.scrollbar import ScrollBar, ScrollBarRender
 from textual.timer import Timer
+from textual.widget import Widget
 from textual.widgets import Button, Input, Static, Tree
 from textual.widgets.tree import TreeNode
 
@@ -1339,6 +1340,90 @@ class TokenDiagnostics(Static):
         return text
 
 
+# ----- Resize Divider -----
+
+
+class ResizeDivider(Widget):
+    """Draggable vertical divider between the chat area and the agents panel.
+
+    Drag left to expand the agents panel; drag right to shrink it (giving more
+    room back to the parent chat area).  Hidden when the agents panel is not
+    visible.
+    """
+
+    DEFAULT_CSS = """
+    ResizeDivider {
+        width: 2;
+        height: 100%;
+        background: #1a1a1a;
+        color: #3a3a3a;
+        display: none;
+        content-align: center middle;
+    }
+    ResizeDivider.visible {
+        display: block;
+    }
+    ResizeDivider:hover {
+        background: #262626;
+        color: #7878b0;
+    }
+    ResizeDivider.dragging {
+        background: #262626;
+        color: #9090d0;
+    }
+    """
+
+    # Each row renders this single character — a thin vertical bar.
+    _CHAR_IDLE = "│"
+    _CHAR_ACTIVE = "┃"
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._dragging: bool = False
+        self._start_x: int = 0
+        self._start_width: int = 84
+
+    def render(self) -> Text:
+        char = self._CHAR_ACTIVE if self._dragging else self._CHAR_IDLE
+        h = max(1, self.size.height)
+        return Text("\n".join([char] * h), no_wrap=True, overflow="fold")
+
+    def on_mouse_down(self, event: events.MouseDown) -> None:
+        self._dragging = True
+        self._start_x = event.screen_x
+        try:
+            panel = self.app.query_one("#agents-panel")
+            self._start_width = panel.size.width
+        except Exception:
+            self._start_width = 84
+        self.add_class("dragging")
+        self.refresh()
+        self.capture_mouse()
+        event.stop()
+
+    def on_mouse_move(self, event: events.MouseMove) -> None:
+        if not self._dragging:
+            return
+        # Drag left  → expand agents-panel (delta negative → new_width grows)
+        # Drag right → shrink agents-panel (delta positive → new_width shrinks)
+        delta = event.screen_x - self._start_x
+        new_width = max(20, self._start_width - delta)
+        try:
+            panel = self.app.query_one("#agents-panel")
+            panel.styles.width = new_width
+        except Exception:
+            pass
+        event.stop()
+
+    def on_mouse_up(self, event: events.MouseUp) -> None:
+        if self._dragging:
+            self._dragging = False
+            self.remove_class("dragging")
+            self.refresh()
+            self.release_mouse()
+        event.stop()
+
+
 # ----- Main TUI App -----
 
 
@@ -1646,6 +1731,9 @@ class PentestAgentTUI(App):
                         )
                     else:
                         yield Input(placeholder="Enter task or type /help", id="chat-input")
+
+            # Resize divider — hidden until agents panel is visible
+            yield ResizeDivider(id="resize-divider")
 
             # Agents panel (right side, hidden by default; shows EmbeddedTerminal widgets)
             with Vertical(id="agents-panel"):
@@ -1999,6 +2087,11 @@ class PentestAgentTUI(App):
             )
             panel.mount(terminal)
             panel.add_class("visible")
+            try:
+                self.query_one("#resize-divider", ResizeDivider).add_class("visible")
+            except Exception:
+                pass
+            self.refresh(layout=True)
             self._add_system(
                 f"[+] Child agent '{message.label}' terminal opened in side panel."
             )
@@ -2031,13 +2124,30 @@ class PentestAgentTUI(App):
 
         try:
             panel = self.query_one("#agents-panel")
-            for widget in panel.query(CollapsibleTerminal):
+
+            # Count terminals that will remain *after* this removal.  We must
+            # do this BEFORE calling remove() because widget.remove() is
+            # deferred in Textual — the DOM query would still find the widget
+            # that is being removed if we check afterwards.
+            all_terminals = list(panel.query(CollapsibleTerminal))
+            remaining_after = [w for w in all_terminals if w._label != message.label]
+
+            for widget in all_terminals:
                 if widget._label == message.label:
                     widget.remove()
                     break
-            # Hide the panel if no terminals remain
-            if not panel.query(CollapsibleTerminal):
+
+            # Hide the panel and resize divider if no terminals will remain,
+            # and reset the panel width so it fills correctly on next spawn.
+            if not remaining_after:
                 panel.remove_class("visible")
+                panel.styles.width = None  # reset to CSS default (84)
+                try:
+                    self.query_one("#resize-divider", ResizeDivider).remove_class("visible")
+                except Exception:
+                    pass
+                self.refresh(layout=True)
+
             self._add_system(
                 f"[-] Child agent '{message.label}' terminal removed from side panel."
             )

--- a/pentestagent/interface/tui.py
+++ b/pentestagent/interface/tui.py
@@ -690,10 +690,23 @@ class MCPScreen(ModalScreen):
         self.app.pop_screen()
 
 
+# ----- MCP task event message (for safe cross-task UI updates) -----
+
+from textual.message import Message
+
+
+class MCPTaskEvent(Message):
+    """Posted by on_mcp_event() so Textual handles the UI update safely."""
+
+    def __init__(self, event: str, data: dict) -> None:
+        super().__init__()
+        self.event = event
+        self.data = data
+
+
 # ----- Copy to clipboard button -----
 
 from textual.events import Click
-from textual.message import Message
 
 class CopyButton(Static):
     """Minimal copy-to-clipboard button using Static instead of Button"""
@@ -951,6 +964,8 @@ class StatusBar(Static):
             text.append("  >> Agent ", style="#9a9a9a")
         elif self.mode == "interact":
             text.append("  >> Interact ", style="#9a9a9a")
+        elif self.mode == "mcp":
+            text.append("  [MCP] ", style="#6b9a9a")
         else:
             text.append("  >> Assist ", style="#9a9a9a")
 
@@ -1410,6 +1425,16 @@ class PentestAgentTUI(App):
         text-style: italic;
     }
 
+    #chat-input:disabled {
+        color: #525252;
+        background: transparent;
+    }
+
+    #input-container.mcp-locked {
+        border: round #1a1a1a;
+        opacity: 0.5;
+    }
+
     #status-bar {
         width: 100%;
         height: 1;
@@ -1513,12 +1538,18 @@ class PentestAgentTUI(App):
         target: Optional[str] = None,
         model: Optional[str] = None,
         use_docker: bool = False,
+        mcp_mode: bool = False,
+        prebuilt_components: Optional[Dict[str, Any]] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.target = target
         self.model = model or DEFAULT_MODEL
         self.use_docker = use_docker
+
+        # MCP observation mode: TUI is read-only and driven by an external MCP server.
+        self.mcp_mode = mcp_mode
+        self._prebuilt_components = prebuilt_components
 
         # Agent components
         self.agent: Optional["PentestAgentAgent"] = None
@@ -1528,10 +1559,13 @@ class PentestAgentTUI(App):
         self.rag_engine = None  # RAG engine
 
         # State
-        self._mode = "assist"  # "assist", "agent", "crew" or "interact"
+        self._mode = "mcp" if mcp_mode else "assist"  # "assist", "agent", "crew", "interact", "mcp"
         self._is_running = False
         self._is_initializing = True  # Block input during init
         self._should_stop = False
+
+        # Per-task tool-message mapping for MCP observation mode
+        self._mcp_tool_messages: Dict[str, Any] = {}
         # Worker handle returned by `@work` or an `asyncio.Task` (keep generic)
         self._current_worker: Optional[Any] = None  # Track running worker for cancellation
         self._current_crew = None  # Track crew orchestrator for cancellation
@@ -1576,7 +1610,14 @@ class PentestAgentTUI(App):
                 yield StatusBar(id="status-bar")
                 with Horizontal(id="input-container"):
                     yield Static("> ", id="chat-prompt")
-                    yield Input(placeholder="Enter task or type /help", id="chat-input")
+                    if self.mcp_mode:
+                        yield Input(
+                            placeholder="MCP Server Mode — read-only, tasks driven by MCP client",
+                            id="chat-input",
+                            disabled=True,
+                        )
+                    else:
+                        yield Input(placeholder="Enter task or type /help", id="chat-input")
 
             # Sidebar (right side, hidden by default)
             with Vertical(id="sidebar"):
@@ -1598,76 +1639,27 @@ class PentestAgentTUI(App):
                 notify("warning", f"TUI: failed to register notifier callback: {e}")
             except Exception as ne:
                 logging.getLogger(__name__).exception("Failed to notify operator about notifier registration failure: %s", ne)
-    
+
         #Added, because the _notes variable is not properly loaded at the beginning and the notes.json is recreated unless you do a /notes command explicitely.
         from ..tools.notes import get_all_notes
         await get_all_notes()
 
-        # Call the textual worker - decorator returns a Worker, not a coroutine
-        _ = cast(Any, self._initialize_agent())
+        if self.mcp_mode:
+            # Activate MCP observation mode using pre-built components.
+            _ = cast(Any, self._activate_mcp_mode())
+        else:
+            # Call the textual worker - decorator returns a Worker, not a coroutine
+            _ = cast(Any, self._initialize_agent())
 
     @work(thread=False)
     async def _initialize_agent(self) -> None:
-        """Initialize agent"""
+        """Initialize agent using the shared component builder."""
         self._set_status("initializing")
 
         try:
-            import os
-
-            from ..agents.pa_agent import PentestAgentAgent
-            from ..knowledge import RAGEngine
-            from ..llm import LLM, ModelConfig
-            from ..mcp import MCPManager
-            from ..runtime.docker_runtime import DockerRuntime
-            from ..runtime.runtime import LocalRuntime
             from ..tools import get_all_tools, register_tool_instance
+            from .initializer import build_agent_components
 
-            # RAG Engine - auto-load knowledge sources
-            rag_doc_count = 0
-            knowledge_path = None
-
-            # Check local knowledge dir first (must have files, not just exist)
-            local_knowledge = Path("knowledge")
-            bundled_path = Path(__file__).parent.parent / "knowledge" / "sources"
-
-            if local_knowledge.exists() and any(local_knowledge.rglob("*.*")):
-                knowledge_path = local_knowledge
-            elif bundled_path.exists():
-                knowledge_path = bundled_path
-
-            if knowledge_path:
-                try:
-                    # Determine embedding method: env var > auto-detect
-                    embeddings_setting = os.getenv(
-                        "PENTESTAGENT_EMBEDDINGS", ""
-                    ).lower()
-                    if embeddings_setting == "local":
-                        use_local = True
-                    elif embeddings_setting == "openai":
-                        use_local = False
-                    else:
-                        # Auto: use OpenAI if key available, else local
-                        use_local = not os.getenv("OPENAI_API_KEY")
-
-                    self.rag_engine = RAGEngine(
-                        knowledge_path=knowledge_path, use_local_embeddings=use_local
-                    )
-                    await asyncio.to_thread(self.rag_engine.index)
-                    rag_doc_count = self.rag_engine.get_document_count()
-                except Exception as e:
-                    self._add_system(f"[!] RAG: {e}")
-                    self.rag_engine = None
-            
-            # Runtime - Docker or Local
-            if self.use_docker:
-                self._add_system("+ Starting Docker container...")
-                self.runtime = DockerRuntime()
-            else:
-                self.runtime = LocalRuntime()
-            await self.runtime.start()
-
-            # LLM
-            # Validate model/runtime presence and provide a user-friendly error
             if not self.model:
                 self._add_system(
                     "[!] No model configured. Set PENTESTAGENT_MODEL environment variable or create a .env file (see .env.example)."
@@ -1676,89 +1668,55 @@ class PentestAgentTUI(App):
                 self._is_initializing = False
                 return
 
-            if not self.runtime:
-                self._add_system("[!] Runtime failed to initialize.")
-                self._set_status("error")
-                self._is_initializing = False
-                return
+            if self.use_docker:
+                self._add_system("+ Starting Docker container...")
 
-            llm = LLM(
-                model=self.model,
-                config=ModelConfig(temperature=0.7),
-                rag_engine=self.rag_engine,
-            )
+            def _on_progress(level: str, msg: str) -> None:
+                if level == "warning":
+                    self._add_system(f"[!] {msg}")
+                # info messages are omitted from TUI chat to keep it clean
 
-            # Tools
-            self.all_tools = get_all_tools()  # Ensure tools are loaded
-
-            # Agent
-            self.agent = PentestAgentAgent(
-                llm=llm,
-                tools=self.all_tools,
-                runtime=self.runtime,
-                target=self.target,
-                rag_engine=self.rag_engine,
-            )
-
-            # Autoinject in the agent the tool that allows to spawn itself as MCP server child connected to this instance
-            from ..tools import create_spawn_mcp_agent_tool
-            spawn_tool = create_spawn_mcp_agent_tool(self.agent)
-            self.agent.add_tools([spawn_tool])
-            
-            try:
-                from ..mcp import MCPManager
-
-                self.mcp_manager = MCPManager()
-                # Start background connect registering tools on the background to not block.
-
-                async def load_mcp() -> None:
-                    tools = await self.mcp_manager.connect_all()
-                    self.agent.add_tools(tools)
-                    for tool in tools:
-                        register_tool_instance(tool)
-                    self.all_tools = get_all_tools()
-                    self._update_header()
-
-                try:
-                    loop = asyncio.get_running_loop()
-                    loop.create_task(load_mcp())
-                except RuntimeError as e:
-                    # No running loop (unlikely in Textual worker), run in thread
-                    import traceback
-                    self._add_system(f"[!] Init failed: {e}\n{traceback.format_exc()}")
-                    self._set_status("error")
-                    try:
-                        asyncio.run(load_mcp())
-                    except Exception as e:
-                        import traceback
-                        self._add_system(f"[!] Init failed: {e}\n{traceback.format_exc()}")
-                        self._set_status("error")
-                mcp_server_count = len(self.mcp_manager.list_configured_servers())
-
-                if self.runtime:
+            # After external MCP tools are loaded, refresh header + tool list.
+            def _after_mcp_load() -> None:
+                self.all_tools = get_all_tools()
+                self._update_header()
+                if self.runtime and self.mcp_manager:
                     self.runtime.mcp_manager = self.mcp_manager
 
-            except Exception as e:
-                self.mcp_manager = None
-                mcp_server_count = 0
-                self._add_system(f"[!] Init failed: {e}\n{traceback.format_exc()}")
-                self._set_status("error")
+            components = await build_agent_components(
+                target        = self.target,
+                scope         = [],
+                model         = self.model,
+                docker        = self.use_docker,
+                no_rag        = False,
+                no_mcp        = False,
+                on_progress   = _on_progress,
+                after_mcp_load= _after_mcp_load,
+            )
 
-            
+            self.agent       = components["agent"]
+            self.runtime     = components["runtime"]
+            self.rag_engine  = components["rag_engine"]
+            self.all_tools   = components["all_tools"]
+            self.mcp_manager = components["mcp_manager"]
+            rag_doc_count    = components["rag_doc_count"]
+            mcp_server_count = components["mcp_server_count"]
+
+            # Wire runtime ↔ MCP manager now that both are ready.
+            if self.runtime and self.mcp_manager:
+                self.runtime.mcp_manager = self.mcp_manager
+
+            # Inject the spawn-as-child-MCP-server tool (TUI-only feature).
+            from ..tools import create_spawn_mcp_agent_tool
+            if self.agent is not None:
+                self.agent.add_tools([create_spawn_mcp_agent_tool(self.agent)])
 
             self._set_status("idle", "assist")
-            self._is_initializing = False  # Allow input now
-
-            # Show ready message
-            tools_str = ", ".join(t.name for t in self.all_tools[:5])
-            if len(self.all_tools) > 5:
-                tools_str += f", +{len(self.all_tools) - 5} more"
+            self._is_initializing = False
 
             runtime_str = "Docker" if self.use_docker else "Local"
-            # Update persistent header instead of adding an ad-hoc system
-            # message to the chat. This keeps the info visible at top.
             self.mcp_server_count = mcp_server_count
-            self.rag_doc_count = rag_doc_count
+            self.rag_doc_count    = rag_doc_count
             try:
                 self._update_header(model_line=(
                     f"+ PentestAgent ready\n"
@@ -1766,14 +1724,12 @@ class PentestAgentTUI(App):
                     f"  Runtime: {runtime_str} | Mode: Assist (use /agent or /crew for autonomous modes)"
                 ))
             except Exception:
-                # Fallback to previous behavior if header widget isn't available
                 self._add_system(
                     f"+ PentestAgent ready\n"
                     f"  Model: {self.model} | Tools: {len(self.all_tools)} | MCP: {mcp_server_count} | RAG: {rag_doc_count}\n"
                     f"  Runtime: {runtime_str} | Mode: Assist (use /agent or /crew for autonomous modes)"
                 )
 
-            # Also update header with target if present
             if self.target:
                 try:
                     self._update_header(target=self.target)
@@ -1785,7 +1741,140 @@ class PentestAgentTUI(App):
 
             self._add_system(f"[!] Init failed: {e}\n{traceback.format_exc()}")
             self._set_status("error")
-            self._is_initializing = False  # Allow input even on error
+            self._is_initializing = False
+
+    # ------------------------------------------------------------------
+    # MCP observation mode
+    # ------------------------------------------------------------------
+
+    @work(thread=False)
+    async def _activate_mcp_mode(self) -> None:
+        """Set up TUI in MCP observation mode using pre-built components."""
+        try:
+            components = self._prebuilt_components or {}
+            self.agent       = components.get("agent")
+            self.runtime     = components.get("runtime")
+            self.rag_engine  = components.get("rag_engine")
+            self.all_tools   = components.get("all_tools") or []
+            self.mcp_manager = components.get("mcp_manager")
+            self.model       = components.get("model") or self.model
+            rag_doc_count    = components.get("rag_doc_count", 0)
+            mcp_server_count = components.get("mcp_server_count", 0)
+
+            # Disable the input widget — operator cannot type commands.
+            try:
+                inp = self.query_one("#chat-input")
+                inp.disabled = True
+            except Exception:
+                pass
+            try:
+                prompt = self.query_one("#chat-prompt")
+                prompt.update("[dim]obs[/] ")
+            except Exception:
+                pass
+            try:
+                container = self.query_one("#input-container")
+                container.add_class("mcp-locked")
+            except Exception:
+                pass
+
+            self._is_initializing = False
+            self._set_status("idle", "mcp")
+
+            self.mcp_server_count = mcp_server_count
+            self.rag_doc_count    = rag_doc_count
+            try:
+                self._update_header(model_line=(
+                    f"+ PentestAgent — MCP Server Mode (read-only)\n"
+                    f"  Model: {self.model} | Tools: {len(self.all_tools)} | MCP servers: {mcp_server_count} | RAG: {rag_doc_count}\n"
+                    f"  Waiting for MCP client tasks…"
+                ))
+            except Exception:
+                self._add_system(
+                    f"+ PentestAgent — MCP Server Mode (read-only)\n"
+                    f"  Model: {self.model} | Tools: {len(self.all_tools)} | MCP: {mcp_server_count} | RAG: {rag_doc_count}"
+                )
+
+            if self.target:
+                try:
+                    self._update_header(target=self.target)
+                except Exception:
+                    pass
+
+        except Exception as e:
+            import traceback
+            self._add_system(f"[!] MCP mode init failed: {e}\n{traceback.format_exc()}")
+            self._set_status("error")
+            self._is_initializing = False
+
+    def on_mcp_event(self, event: str, data: dict) -> None:
+        """Called by mcp_tools._emit() from an asyncio task.
+
+        Does NOT touch any Textual widgets directly — instead posts a
+        MCPTaskEvent message so Textual dispatches the update safely inside
+        its own message loop (avoids NoMatches / DOM-not-ready races).
+        """
+        try:
+            self.post_message(MCPTaskEvent(event, data))
+        except Exception as e:
+            logging.getLogger(__name__).exception("MCP post_message failed: %s", e)
+
+    @on(MCPTaskEvent)
+    def handle_mcp_task_event(self, message: MCPTaskEvent) -> None:
+        """Handle MCP task events inside Textual's message loop (DOM is ready)."""
+        event = message.event
+        data  = message.data
+        try:
+            if event == "task_start":
+                task   = data.get("task", "")
+                target = data.get("target")
+                label  = f"[MCP task] {task}"
+                if target:
+                    label += f"  (target: {target})"
+                self._add_user(label)
+                self._set_status("running", "mcp")
+                self._is_running = True
+                self._mcp_tool_messages = {}
+
+            elif event == "thinking":
+                content = data.get("content", "")
+                if content:
+                    self._add_thinking(content)
+
+            elif event == "content":
+                content = data.get("content", "")
+                if content:
+                    self._add_assistant(content)
+
+            elif event == "tool_call":
+                call_id   = data.get("id", "")
+                name      = data.get("name", "")
+                arguments = data.get("arguments", {})
+                tm = self._add_tool(name, str(arguments))
+                self._mcp_tool_messages[call_id] = tm
+
+            elif event == "tool_result":
+                call_id   = data.get("tool_call_id", "")
+                tool_name = data.get("tool_name", "")
+                result    = data.get("result", "")
+                success   = data.get("success", True)
+                tm = self._mcp_tool_messages.get(call_id)
+                if tm is not None:
+                    label = result if success else f"Error: {result}"
+                    self._add_tool_result(tm, tool_name, label or "Done")
+
+            elif event == "task_done":
+                status = data.get("status", "done")
+                error  = data.get("error")
+                if status == "error" and error:
+                    self._add_system(f"[!] Task error: {error}")
+                elif status == "cancelled":
+                    self._add_system("[!] Task cancelled.")
+                self._set_status("idle", "mcp")
+                self._is_running = False
+
+        except Exception as e:
+            logging.getLogger(__name__).exception("MCP task event handler error: %s", e)
 
     def _set_status(self, status: str, mode: Optional[str] = None) -> None:
         """Update status bar"""
@@ -2320,6 +2409,12 @@ Be concise. Use the actual data from notes."""
     @on(Input.Submitted, "#chat-input")
     async def handle_submit(self, event: Input.Submitted) -> None:
         """Handle input submission"""
+        # MCP observation mode: the input is disabled at the widget level, but
+        # guard here as well to be safe.
+        if self.mcp_mode:
+            event.input.value = ""
+            return
+
         # Block input while initializing or AI is processing
         if self._is_initializing or self._is_running:
             return

--- a/pentestagent/interface/tui.py
+++ b/pentestagent/interface/tui.py
@@ -1731,10 +1731,13 @@ class PentestAgentTUI(App):
             if self.runtime and self.mcp_manager:
                 self.runtime.mcp_manager = self.mcp_manager
 
-            # Inject the spawn-as-child-MCP-server tool (TUI-only feature).
-            from ..tools import create_spawn_mcp_agent_tool
+            # Inject spawn/despawn child-MCP-server tools (TUI-only feature).
+            from ..tools import create_spawn_mcp_agent_tool, create_despawn_mcp_agent_tool
             if self.agent is not None:
-                self.agent.add_tools([create_spawn_mcp_agent_tool(self.agent)])
+                self.agent.add_tools([
+                    create_spawn_mcp_agent_tool(self.agent),
+                    create_despawn_mcp_agent_tool(self.agent),
+                ])
 
             self._set_status("idle", "assist")
             self._is_initializing = False

--- a/pentestagent/interface/tui.py
+++ b/pentestagent/interface/tui.py
@@ -713,6 +713,14 @@ class SpawnTerminalMessage(Message):
         self.label = label
 
 
+class DespawnTerminalMessage(Message):
+    """Posted when a child agent has been despawned and its terminal should be removed."""
+
+    def __init__(self, label: str) -> None:
+        super().__init__()
+        self.label = label
+
+
 # ----- Copy to clipboard button -----
 
 from textual.events import Click
@@ -1652,10 +1660,15 @@ class PentestAgentTUI(App):
         """Initialize on mount"""
         # Register notifier callback so other modules can emit operator-visible messages
         try:
-            from .notifier import register_callback, register_spawn_terminal_callback
+            from .notifier import (
+                register_callback,
+                register_spawn_terminal_callback,
+                register_despawn_terminal_callback,
+            )
 
             register_callback(self._notifier_callback)
             register_spawn_terminal_callback(self._spawn_terminal_callback)
+            register_despawn_terminal_callback(self._despawn_terminal_callback)
         except Exception as e:
             logging.getLogger(__name__).exception("Failed to register TUI notifier callback: %s", e)
             try:
@@ -1992,6 +2005,45 @@ class PentestAgentTUI(App):
         except Exception as e:
             logging.getLogger(__name__).exception(
                 "Failed to mount EmbeddedTerminal: %s", e
+            )
+
+    def _despawn_terminal_callback(self, label: str) -> None:
+        """Callback wired to `notifier.register_despawn_terminal_callback`."""
+        try:
+            if hasattr(self, "call_from_thread"):
+                try:
+                    self.call_from_thread(
+                        self.post_message, DespawnTerminalMessage(label)
+                    )
+                    return
+                except Exception:
+                    pass
+            self.post_message(DespawnTerminalMessage(label))
+        except Exception as e:
+            logging.getLogger(__name__).exception(
+                "despawn_terminal_callback failed: %s", e
+            )
+
+    @on(DespawnTerminalMessage)
+    def _handle_despawn_terminal(self, message: DespawnTerminalMessage) -> None:
+        """Unmount the CollapsibleTerminal whose label matches the despawned agent."""
+        from .widgets import CollapsibleTerminal
+
+        try:
+            panel = self.query_one("#agents-panel")
+            for widget in panel.query(CollapsibleTerminal):
+                if widget._label == message.label:
+                    widget.remove()
+                    break
+            # Hide the panel if no terminals remain
+            if not panel.query(CollapsibleTerminal):
+                panel.remove_class("visible")
+            self._add_system(
+                f"[-] Child agent '{message.label}' terminal removed from side panel."
+            )
+        except Exception as e:
+            logging.getLogger(__name__).exception(
+                "Failed to unmount CollapsibleTerminal: %s", e
             )
 
     def _add_message(self, widget: Static) -> None:

--- a/pentestagent/interface/tui.py
+++ b/pentestagent/interface/tui.py
@@ -1975,12 +1975,12 @@ class PentestAgentTUI(App):
 
     @on(SpawnTerminalMessage)
     def _handle_spawn_terminal(self, message: SpawnTerminalMessage) -> None:
-        """Mount an EmbeddedTerminal widget and show the agents panel."""
-        from .widgets import EmbeddedTerminal
+        """Mount a CollapsibleTerminal widget and show the agents panel."""
+        from .widgets import CollapsibleTerminal
 
         try:
             panel = self.query_one("#agents-panel")
-            terminal = EmbeddedTerminal(
+            terminal = CollapsibleTerminal(
                 master_fd=message.master_fd,
                 label=message.label,
             )

--- a/pentestagent/interface/tui.py
+++ b/pentestagent/interface/tui.py
@@ -704,6 +704,15 @@ class MCPTaskEvent(Message):
         self.data = data
 
 
+class SpawnTerminalMessage(Message):
+    """Posted when a child agent requests an EmbeddedTerminal widget."""
+
+    def __init__(self, master_fd: int, label: str) -> None:
+        super().__init__()
+        self.master_fd = master_fd
+        self.label = label
+
+
 # ----- Copy to clipboard button -----
 
 from textual.events import Click
@@ -1459,6 +1468,17 @@ class PentestAgentTUI(App):
         display: block;
     }
 
+    #agents-panel {
+        width: 84;
+        height: 100%;
+        display: none;
+        padding-right: 1;
+    }
+
+    #agents-panel.visible {
+        display: block;
+    }
+
     #workers-tree {
         height: 1fr;
         background: transparent;
@@ -1619,6 +1639,10 @@ class PentestAgentTUI(App):
                     else:
                         yield Input(placeholder="Enter task or type /help", id="chat-input")
 
+            # Agents panel (right side, hidden by default; shows EmbeddedTerminal widgets)
+            with Vertical(id="agents-panel"):
+                pass
+
             # Sidebar (right side, hidden by default)
             with Vertical(id="sidebar"):
                 yield CrewTree("CREW", id="workers-tree")
@@ -1628,9 +1652,10 @@ class PentestAgentTUI(App):
         """Initialize on mount"""
         # Register notifier callback so other modules can emit operator-visible messages
         try:
-            from .notifier import register_callback
+            from .notifier import register_callback, register_spawn_terminal_callback
 
             register_callback(self._notifier_callback)
+            register_spawn_terminal_callback(self._spawn_terminal_callback)
         except Exception as e:
             logging.getLogger(__name__).exception("Failed to register TUI notifier callback: %s", e)
             try:
@@ -1923,6 +1948,48 @@ class PentestAgentTUI(App):
             self._show_notification(level, message)
         except Exception as e:
             logging.getLogger(__name__).exception("Exception in notifier callback handling: %s", e)
+
+    def _spawn_terminal_callback(self, master_fd: int, label: str) -> None:
+        """Callback wired to `notifier.register_spawn_terminal_callback`.
+
+        Called from an asyncio task (agent tool execution), so we route
+        through post_message / call_from_thread to stay on the Textual loop.
+        """
+        try:
+            if hasattr(self, "call_from_thread"):
+                try:
+                    self.call_from_thread(
+                        self.post_message, SpawnTerminalMessage(master_fd, label)
+                    )
+                    return
+                except Exception:
+                    pass
+            self.post_message(SpawnTerminalMessage(master_fd, label))
+        except Exception as e:
+            logging.getLogger(__name__).exception(
+                "spawn_terminal_callback failed: %s", e
+            )
+
+    @on(SpawnTerminalMessage)
+    def _handle_spawn_terminal(self, message: SpawnTerminalMessage) -> None:
+        """Mount an EmbeddedTerminal widget and show the agents panel."""
+        from .widgets import EmbeddedTerminal
+
+        try:
+            panel = self.query_one("#agents-panel")
+            terminal = EmbeddedTerminal(
+                master_fd=message.master_fd,
+                label=message.label,
+            )
+            panel.mount(terminal)
+            panel.add_class("visible")
+            self._add_system(
+                f"[+] Child agent '{message.label}' terminal opened in side panel."
+            )
+        except Exception as e:
+            logging.getLogger(__name__).exception(
+                "Failed to mount EmbeddedTerminal: %s", e
+            )
 
     def _add_message(self, widget: Static) -> None:
         """Add a message widget to chat"""

--- a/pentestagent/interface/widgets/__init__.py
+++ b/pentestagent/interface/widgets/__init__.py
@@ -1,3 +1,4 @@
 from .embedded_terminal import EmbeddedTerminal
+from .collapsible_terminal import CollapsibleTerminal
 
-__all__ = ["EmbeddedTerminal"]
+__all__ = ["EmbeddedTerminal", "CollapsibleTerminal"]

--- a/pentestagent/interface/widgets/__init__.py
+++ b/pentestagent/interface/widgets/__init__.py
@@ -1,0 +1,3 @@
+from .embedded_terminal import EmbeddedTerminal
+
+__all__ = ["EmbeddedTerminal"]

--- a/pentestagent/interface/widgets/collapsible_terminal.py
+++ b/pentestagent/interface/widgets/collapsible_terminal.py
@@ -1,0 +1,82 @@
+"""CollapsibleTerminal — wraps EmbeddedTerminal with a clickable title header.
+
+Clicking the header collapses/expands the terminal.  When collapsed the inner
+EmbeddedTerminal gets ``display: none``, which causes Textual to skip
+rendering it entirely.  The PTY reader thread keeps running (so the child
+process stays alive) but no screen redraws are scheduled, keeping CPU overhead
+minimal for invisible panels.
+"""
+from __future__ import annotations
+
+from textual import events, on
+from textual.reactive import reactive
+from textual.widget import Widget
+from textual.widgets import Static
+
+from .embedded_terminal import EmbeddedTerminal
+
+
+class CollapsibleTerminal(Widget):
+    """Collapsible container around an :class:`EmbeddedTerminal`.
+
+    The header row shows ``▼ label`` when expanded and ``▶ label`` when
+    collapsed.  Click the header to toggle.  When collapsed the widget shrinks
+    to three rows (top-border + header + bottom-border) and the embedded
+    terminal is hidden via ``display: none`` so Textual skips rendering it.
+    """
+
+    collapsed: reactive[bool] = reactive(False)
+
+    DEFAULT_CSS = """
+    CollapsibleTerminal {
+        height: 1fr;
+        border: round #3a3a3a;
+        margin-bottom: 1;
+    }
+    CollapsibleTerminal.collapsed {
+        height: 3;
+    }
+    CollapsibleTerminal > ._ct-header {
+        height: 1;
+        padding: 0 1;
+        color: #7878b0;
+    }
+    CollapsibleTerminal > ._ct-header:hover {
+        background: #1a1a3a;
+        color: #c0c0f0;
+    }
+    CollapsibleTerminal > EmbeddedTerminal {
+        height: 1fr;
+        border: none;
+    }
+    CollapsibleTerminal.collapsed > EmbeddedTerminal {
+        display: none;
+    }
+    """
+
+    def __init__(self, master_fd: int, label: str = "agent", **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._master_fd = master_fd
+        self._label = label
+
+    def compose(self):  # type: ignore[override]
+        yield Static(f"▼  {self._label}", classes="_ct-header", markup=False)
+        yield EmbeddedTerminal(master_fd=self._master_fd, label=self._label)
+
+    # ── Reactive watcher ──────────────────────────────────────────────────────
+
+    def watch_collapsed(self, value: bool) -> None:
+        """Sync CSS class and header icon whenever *collapsed* changes."""
+        self.set_class(value, "collapsed")
+        icon = "▶" if value else "▼"
+        try:
+            self.query_one("._ct-header", Static).update(f"{icon}  {self._label}")
+        except Exception:
+            pass
+
+    # ── Header click → toggle ─────────────────────────────────────────────────
+
+    @on(events.Click, "._ct-header")
+    def _on_header_click(self, event: events.Click) -> None:
+        self.collapsed = not self.collapsed
+        event.stop()

--- a/pentestagent/interface/widgets/embedded_terminal.py
+++ b/pentestagent/interface/widgets/embedded_terminal.py
@@ -1,0 +1,191 @@
+"""EmbeddedTerminal — Textual widget that renders a child-agent PTY.
+
+The widget holds the *master* end of a PTY pair.  The child process writes
+its TUI output to the *slave* end; this widget reads from the master,
+feeds the bytes through a pyte VT100 emulator, and renders the resulting
+screen as Rich Text — colours, bold, underline and reverse included.
+
+The widget is **read-only**: keyboard input is not forwarded to the child.
+The child is driven exclusively via MCP (FIFOs), not via the PTY.
+
+Resize events propagate to the child via TIOCSWINSZ so its TUI reflows
+when the panel is resized.
+"""
+from __future__ import annotations
+
+import asyncio
+import fcntl
+import os
+import select
+import struct
+import termios
+
+try:
+    import pyte
+    _PYTE_OK = True
+except ImportError:
+    pyte = None  # type: ignore
+    _PYTE_OK = False
+
+from rich.style import Style
+from rich.text import Text
+from textual import work
+from textual.app import RenderableType
+from textual.widget import Widget
+
+
+# ── pyte colour → Rich colour ─────────────────────────────────────────────────
+
+_NAMED: dict[str, str] = {
+    "black":         "black",
+    "red":           "red",
+    "green":         "green",
+    "yellow":        "yellow",
+    "blue":          "blue",
+    "magenta":       "magenta",
+    "cyan":          "cyan",
+    "white":         "white",
+    "brightblack":   "bright_black",
+    "brightred":     "bright_red",
+    "brightgreen":   "bright_green",
+    "brightyellow":  "bright_yellow",
+    "brightblue":    "bright_blue",
+    "brightmagenta": "bright_magenta",
+    "brightcyan":    "bright_cyan",
+    "brightwhite":   "bright_white",
+}
+
+
+_HEX6 = frozenset("0123456789abcdefABCDEF")
+
+
+def _rich_color(c: "str | int") -> "str | None":
+    if c == "default":
+        return None
+    if isinstance(c, int):
+        return f"color({c})"
+    # pyte returns true-color as a bare 6-char hex string (no '#')
+    if len(c) == 6 and all(ch in _HEX6 for ch in c):
+        return f"#{c}"
+    return _NAMED.get(c, c) or None
+
+
+# ── Widget ────────────────────────────────────────────────────────────────────
+
+class EmbeddedTerminal(Widget):
+    """Read-only embedded terminal that renders a child process's PTY output."""
+
+    DEFAULT_CSS = """
+    EmbeddedTerminal {
+        height: 1fr;
+        border: round #3a3a3a;
+        border-title-color: #9a9a9a;
+        border-title-style: bold;
+        background: #0a0a0a;
+        color: #d4d4d4;
+        padding: 0;
+    }
+    EmbeddedTerminal:focus {
+        border: round #525252;
+    }
+    """
+
+    def __init__(self, master_fd: int, label: str = "agent", **kwargs):
+        super().__init__(**kwargs)
+        self._master_fd = master_fd
+        self._label = label
+        if _PYTE_OK:
+            self._screen: pyte.Screen = pyte.Screen(80, 24)
+            self._stream: pyte.Stream = pyte.Stream(self._screen)
+        else:
+            self._screen = None
+            self._stream = None
+        self.border_title = label
+
+    # ── Lifecycle ─────────────────────────────────────────────────────────────
+
+    def on_mount(self) -> None:
+        self._pty_reader()
+
+    def on_unmount(self) -> None:
+        try:
+            os.close(self._master_fd)
+        except OSError:
+            pass
+
+    # ── PTY reader (background worker) ───────────────────────────────────────
+
+    @work(exclusive=True, thread=False)
+    async def _pty_reader(self) -> None:
+        """Poll the master PTY fd and update the pyte screen on new data."""
+        loop = asyncio.get_running_loop()
+        while True:
+            try:
+                r, _, _ = await loop.run_in_executor(
+                    None,
+                    lambda: select.select([self._master_fd], [], [], 0.05),
+                )
+                if r:
+                    data = os.read(self._master_fd, 65536)
+                    if not data:
+                        break
+                    if self._stream is not None:
+                        self._stream.feed(data.decode("utf-8", errors="replace"))
+                    self.refresh()
+            except OSError:
+                break
+            except asyncio.CancelledError:
+                break
+
+    # ── Resize propagation ────────────────────────────────────────────────────
+
+    def on_resize(self, event) -> None:
+        # Subtract 2 for the border on each axis.
+        rows = max(1, event.size.height - 2)
+        cols = max(1, event.size.width - 2)
+        if self._screen is not None:
+            self._screen.resize(rows, cols)
+        try:
+            fcntl.ioctl(
+                self._master_fd,
+                termios.TIOCSWINSZ,
+                struct.pack("HHHH", rows, cols, 0, 0),
+            )
+        except OSError:
+            pass
+
+    # ── Rendering ─────────────────────────────────────────────────────────────
+
+    def render(self) -> RenderableType:
+        if self._screen is None:
+            return Text(
+                "pyte not installed — run: pip install pyte",
+                style=Style(color="red", dim=True),
+            )
+
+        result = Text(no_wrap=True, overflow="fold")
+        buf = self._screen.buffer
+        for y in range(self._screen.lines):
+            row = buf[y]
+            for x in range(self._screen.columns):
+                char = row[x]
+                try:
+                    sty = Style()
+                    fg = _rich_color(char.fg)
+                    bg = _rich_color(char.bg)
+                    if fg:
+                        sty += Style(color=fg)
+                    if bg:
+                        sty += Style(bgcolor=bg)
+                    if char.bold:
+                        sty += Style(bold=True)
+                    if char.underscore:
+                        sty += Style(underline=True)
+                    if char.reverse:
+                        sty += Style(reverse=True)
+                except Exception:
+                    sty = Style()
+                result.append(char.data or " ", style=sty)
+            if y < self._screen.lines - 1:
+                result.append("\n")
+        return result

--- a/pentestagent/interface/widgets/embedded_terminal.py
+++ b/pentestagent/interface/widgets/embedded_terminal.py
@@ -244,6 +244,18 @@ class EmbeddedTerminal(Widget):
         event.stop()
         self._sgr_mouse(event, 65, press=True)
 
+    def on_mouse_move(self, event: events.MouseMove) -> None:
+        event.stop()
+        # SGR button 32 = motion with no button held; add pressed-button bits if needed
+        btn = 32
+        if event.button == 1:
+            btn |= 0   # left held during move — already motion
+        elif event.button == 2:
+            btn |= 2
+        elif event.button == 3:
+            btn |= 1
+        self._sgr_mouse(event, btn, press=True)
+
     # ── Resize propagation ────────────────────────────────────────────────────
 
     def on_resize(self, event: events.Resize) -> None:

--- a/pentestagent/interface/widgets/embedded_terminal.py
+++ b/pentestagent/interface/widgets/embedded_terminal.py
@@ -5,8 +5,10 @@ its TUI output to the *slave* end; this widget reads from the master,
 feeds the bytes through a pyte VT100 emulator, and renders the resulting
 screen as Rich Text — colours, bold, underline and reverse included.
 
-The widget is **read-only**: keyboard input is not forwarded to the child.
-The child is driven exclusively via MCP (FIFOs), not via the PTY.
+Keyboard input and scroll-wheel events are forwarded to the child via the
+master fd so the child's TUI remains fully interactive when the widget has
+focus.  Mouse click events request focus so the user can start typing
+immediately after clicking.
 
 Resize events propagate to the child via TIOCSWINSZ so its TUI reflows
 when the panel is resized.
@@ -29,7 +31,7 @@ except ImportError:
 
 from rich.style import Style
 from rich.text import Text
-from textual import work
+from textual import events, work
 from textual.app import RenderableType
 from textual.widget import Widget
 
@@ -55,7 +57,6 @@ _NAMED: dict[str, str] = {
     "brightwhite":   "bright_white",
 }
 
-
 _HEX6 = frozenset("0123456789abcdefABCDEF")
 
 
@@ -70,10 +71,50 @@ def _rich_color(c: "str | int") -> "str | None":
     return _NAMED.get(c, c) or None
 
 
+# ── Key → PTY byte mapping ────────────────────────────────────────────────────
+
+# Maps Textual key names to the byte sequences a VT100 terminal sends.
+_KEY_MAP: dict[str, bytes] = {
+    "enter":        b"\r",
+    "backspace":    b"\x7f",
+    "tab":          b"\t",
+    "escape":       b"\x1b",
+    "up":           b"\x1b[A",
+    "down":         b"\x1b[B",
+    "right":        b"\x1b[C",
+    "left":         b"\x1b[D",
+    "home":         b"\x1b[H",
+    "end":          b"\x1b[F",
+    "pageup":       b"\x1b[5~",
+    "pagedown":     b"\x1b[6~",
+    "delete":       b"\x1b[3~",
+    "insert":       b"\x1b[2~",
+    # Function keys
+    "f1":           b"\x1bOP",
+    "f2":           b"\x1bOQ",
+    "f3":           b"\x1bOR",
+    "f4":           b"\x1bOS",
+    "f5":           b"\x1b[15~",
+    "f6":           b"\x1b[17~",
+    "f7":           b"\x1b[18~",
+    "f8":           b"\x1b[19~",
+    "f9":           b"\x1b[20~",
+    "f10":          b"\x1b[21~",
+    "f11":          b"\x1b[23~",
+    "f12":          b"\x1b[24~",
+}
+
+# ctrl+a … ctrl+z → 0x01 … 0x1a
+for _i, _c in enumerate("abcdefghijklmnopqrstuvwxyz", 1):
+    _KEY_MAP[f"ctrl+{_c}"] = bytes([_i])
+
+
 # ── Widget ────────────────────────────────────────────────────────────────────
 
 class EmbeddedTerminal(Widget):
-    """Read-only embedded terminal that renders a child process's PTY output."""
+    """Interactive embedded terminal that renders a child process's PTY output."""
+
+    can_focus = True  # must be True to receive keyboard events
 
     DEFAULT_CSS = """
     EmbeddedTerminal {
@@ -84,6 +125,7 @@ class EmbeddedTerminal(Widget):
         background: #0a0a0a;
         color: #d4d4d4;
         padding: 0;
+        overflow: hidden;
     }
     EmbeddedTerminal:focus {
         border: round #525252;
@@ -137,11 +179,75 @@ class EmbeddedTerminal(Widget):
             except asyncio.CancelledError:
                 break
 
+    # ── PTY writer helper ─────────────────────────────────────────────────────
+
+    def _write_pty(self, data: bytes) -> None:
+        try:
+            os.write(self._master_fd, data)
+        except OSError:
+            pass
+
+    # ── Keyboard input forwarding ─────────────────────────────────────────────
+
+    def on_key(self, event: events.Key) -> None:
+        event.stop()
+        # Printable character — send its UTF-8 encoding directly.
+        if event.character and len(event.character) == 1 and event.character.isprintable():
+            self._write_pty(event.character.encode("utf-8"))
+            return
+        seq = _KEY_MAP.get(event.key)
+        if seq:
+            self._write_pty(seq)
+
+    # ── Mouse input forwarding ────────────────────────────────────────────────
+
+    def _sgr_mouse(self, event: events.MouseEvent, button_code: int, press: bool) -> None:
+        """Write an SGR mouse escape sequence to the PTY.
+
+        Format: ESC [ < Cb ; Cx ; Cy M   (press)
+                ESC [ < Cb ; Cx ; Cy m   (release)
+
+        Cb  = button code (0=left, 1=middle, 2=right, 64=scroll-up, 65=scroll-down)
+              plus modifier bits: shift=4, alt/meta=8, ctrl=16
+        Cx/Cy = 1-based column/row relative to the widget content area.
+        """
+        btn = button_code
+        if event.shift:
+            btn |= 4
+        if event.meta:
+            btn |= 8
+        if event.ctrl:
+            btn |= 16
+        # event.x/y are 0-based inside the widget content area; PTY wants 1-based
+        cx = max(1, event.x + 1)
+        cy = max(1, event.y + 1)
+        suffix = "M" if press else "m"
+        self._write_pty(f"\x1b[<{btn};{cx};{cy}{suffix}".encode())
+
+    def on_mouse_down(self, event: events.MouseDown) -> None:
+        event.stop()
+        self.focus()
+        # Textual: 1=left, 2=right, 3=middle → SGR: 0=left, 2=right, 1=middle
+        btn = {1: 0, 2: 2, 3: 1}.get(event.button, 0)
+        self._sgr_mouse(event, btn, press=True)
+
+    def on_mouse_up(self, event: events.MouseUp) -> None:
+        event.stop()
+        btn = {1: 0, 2: 2, 3: 1}.get(event.button, 0)
+        self._sgr_mouse(event, btn, press=False)
+
+    def on_mouse_scroll_up(self, event: events.MouseScrollUp) -> None:
+        event.stop()
+        self._sgr_mouse(event, 64, press=True)
+
+    def on_mouse_scroll_down(self, event: events.MouseScrollDown) -> None:
+        event.stop()
+        self._sgr_mouse(event, 65, press=True)
+
     # ── Resize propagation ────────────────────────────────────────────────────
 
-    def on_resize(self, event) -> None:
-        # Subtract 2 for the border on each axis.
-        rows = max(1, event.size.height - 2)
+    def on_resize(self, event: events.Resize) -> None:
+        rows = max(1, event.size.height - 2)  # subtract border
         cols = max(1, event.size.width - 2)
         if self._screen is not None:
             self._screen.resize(rows, cols)

--- a/pentestagent/interface/widgets/embedded_terminal.py
+++ b/pentestagent/interface/widgets/embedded_terminal.py
@@ -21,6 +21,7 @@ import os
 import select
 import struct
 import termios
+import time
 
 try:
     import pyte
@@ -132,6 +133,9 @@ class EmbeddedTerminal(Widget):
     }
     """
 
+    # Minimum interval between screen refreshes (≈30 fps).
+    _REFRESH_INTERVAL = 1 / 30
+
     def __init__(self, master_fd: int, label: str = "agent", **kwargs):
         super().__init__(**kwargs)
         self._master_fd = master_fd
@@ -155,28 +159,34 @@ class EmbeddedTerminal(Widget):
         except OSError:
             pass
 
-    # ── PTY reader (background worker) ───────────────────────────────────────
+    # ── PTY reader (thread worker + select) ───────────────────────────────────
 
-    @work(exclusive=True, thread=False)
-    async def _pty_reader(self) -> None:
-        """Poll the master PTY fd and update the pyte screen on new data."""
-        loop = asyncio.get_running_loop()
+    @work(exclusive=True, thread=True)
+    def _pty_reader(self) -> None:
+        """Read the master PTY fd in a background thread.
+
+        select.select() is used because PTY master fds are not reliably
+        pollable via epoll (used by asyncio.add_reader on Linux).
+
+        Refreshes are rate-limited to ~30 fps so the Textual render loop is
+        not flooded when the child outputs large amounts of text.
+        """
+        last_refresh = 0.0
         while True:
             try:
-                r, _, _ = await loop.run_in_executor(
-                    None,
-                    lambda: select.select([self._master_fd], [], [], 0.05),
-                )
-                if r:
-                    data = os.read(self._master_fd, 65536)
-                    if not data:
-                        break
-                    if self._stream is not None:
-                        self._stream.feed(data.decode("utf-8", errors="replace"))
+                r, _, _ = select.select([self._master_fd], [], [], 0.05)
+                if not r:
+                    continue
+                data = os.read(self._master_fd, 65536)
+                if not data:
+                    break
+                if self._stream is not None:
+                    self._stream.feed(data.decode("utf-8", errors="replace"))
+                now = time.monotonic()
+                if now - last_refresh >= self._REFRESH_INTERVAL:
+                    last_refresh = now
                     self.refresh()
             except OSError:
-                break
-            except asyncio.CancelledError:
                 break
 
     # ── PTY writer helper ─────────────────────────────────────────────────────
@@ -209,7 +219,13 @@ class EmbeddedTerminal(Widget):
 
         Cb  = button code (0=left, 1=middle, 2=right, 64=scroll-up, 65=scroll-down)
               plus modifier bits: shift=4, alt/meta=8, ctrl=16
-        Cx/Cy = 1-based column/row relative to the widget content area.
+        Cx/Cy = 1-based column/row.
+
+        Textual dispatches mouse events with coordinates relative to the
+        widget's outer region (border included).  The border is 1 cell on
+        each side, so the content area starts at (1, 1).  To convert to
+        1-based PTY coordinates we therefore use event.x / event.y directly
+        (no extra +1 needed — the border offset already provides it).
         """
         btn = button_code
         if event.shift:
@@ -218,21 +234,26 @@ class EmbeddedTerminal(Widget):
             btn |= 8
         if event.ctrl:
             btn |= 16
-        # event.x/y are 0-based inside the widget content area; PTY wants 1-based
-        cx = max(1, event.x + 1)
-        cy = max(1, event.y + 1)
+        # Widget coords are 0-based and include the 1-cell border, so the first
+        # content cell is at (1, 1) → PTY row/col 1 = max(1, event.x/y).
+        cx = max(1, event.x)
+        cy = max(1, event.y)
         suffix = "M" if press else "m"
         self._write_pty(f"\x1b[<{btn};{cx};{cy}{suffix}".encode())
 
     def on_mouse_down(self, event: events.MouseDown) -> None:
         event.stop()
+        event.prevent_default()
         self.focus()
+        self.capture_mouse()  # own all mouse events until mouse_up
         # Textual: 1=left, 2=right, 3=middle → SGR: 0=left, 2=right, 1=middle
         btn = {1: 0, 2: 2, 3: 1}.get(event.button, 0)
         self._sgr_mouse(event, btn, press=True)
 
     def on_mouse_up(self, event: events.MouseUp) -> None:
         event.stop()
+        event.prevent_default()
+        self.release_mouse()
         btn = {1: 0, 2: 2, 3: 1}.get(event.button, 0)
         self._sgr_mouse(event, btn, press=False)
 
@@ -246,10 +267,11 @@ class EmbeddedTerminal(Widget):
 
     def on_mouse_move(self, event: events.MouseMove) -> None:
         event.stop()
-        # SGR button 32 = motion with no button held; add pressed-button bits if needed
+        event.prevent_default()
+        # SGR button 32 = motion; add held-button bits if a button is pressed.
         btn = 32
         if event.button == 1:
-            btn |= 0   # left held during move — already motion
+            btn |= 0   # left — motion base already covers it
         elif event.button == 2:
             btn |= 2
         elif event.button == 3:

--- a/pentestagent/mcp/manager.py
+++ b/pentestagent/mcp/manager.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, List, Optional
 from abc import ABC
 
 from ..tools import Tool
-from .transport import MCPTransport, StdioTransport, SSETransport
+from .transport import MCPTransport, StdioTransport, SSETransport, FifoTransport
 
 
 @dataclass
@@ -44,6 +44,17 @@ class StdioServerConfig(MCPServerConfig):
 
     def __post_init__(self):
         self.type = "stdio"
+
+
+@dataclass
+class FifoServerConfig(MCPServerConfig):
+    """Configuration for a FIFO-based MCP server (TUI child in a new terminal)."""
+
+    fifo_in: str = ""   # parent writes, child reads (MCP requests)
+    fifo_out: str = ""  # child writes, parent reads (MCP responses)
+
+    def __post_init__(self):
+        self.type = "fifo"
 
 
 @dataclass
@@ -298,12 +309,16 @@ class MCPManager:
 
             if isinstance(config, SSEServerConfig):
                 transport = SSETransport(url=config.url, bearer=config.bearer)
+            elif isinstance(config, FifoServerConfig):
+                transport = FifoTransport(
+                    fifo_in=config.fifo_in, fifo_out=config.fifo_out
+                )
             elif isinstance(config, StdioServerConfig):
                 env = {**os.environ, **config.env}
                 transport = StdioTransport(
                     command=config.command, args=config.args, env=env
                 )
-            
+
             if transport is None:
                 raise RuntimeError("Failed to create transport")
 

--- a/pentestagent/mcp/mcp_servers.json
+++ b/pentestagent/mcp/mcp_servers.json
@@ -1,3 +1,0 @@
-{
-  "mcpServers": {}
-}

--- a/pentestagent/mcp/server/mcp_tools.py
+++ b/pentestagent/mcp/server/mcp_tools.py
@@ -4,7 +4,7 @@ import asyncio
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, TYPE_CHECKING, Optional, Type
+from typing import Any, Callable, TYPE_CHECKING, Optional, Type
 
 from .mcp_core import ToolRegistry
 
@@ -22,6 +22,26 @@ _LLMClass:       Optional[Type[LLM]]         = None
 _RuntimeClass:   Optional[Type[Runtime]]     = None
 _llm_kwargs:     dict[str, Any]              = {}
 _runtime_kwargs: dict[str, Any]              = {}
+
+# Optional UI hook: called with (event_type: str, data: dict) for each
+# significant event during task execution.  Registered by the TUI when
+# running in MCP observation mode.
+_ui_hook: Optional[Callable[[str, dict], None]] = None
+
+
+def set_ui_hook(hook: Optional[Callable[[str, dict], None]]) -> None:
+    """Register (or clear) the UI event hook.  Thread-safe write."""
+    global _ui_hook
+    _ui_hook = hook
+
+
+def _emit(event: str, data: dict) -> None:
+    """Deliver a UI event if a hook is registered, swallowing any errors."""
+    if _ui_hook is not None:
+        try:
+            _ui_hook(event, data)
+        except Exception:
+            pass
 
 _tasks:  dict[str, TaskEntry]      = {}
 _memory: dict[str, dict[str, str]] = {}
@@ -128,6 +148,12 @@ async def _drive_task(entry: TaskEntry) -> None:
     entry.status = "running"
     output_parts: list[str] = []
 
+    _emit("task_start", {
+        "task_id": entry.id,
+        "task":    entry.task,
+        "target":  entry.target,
+    })
+
     try:
         async for response in entry.agent.run_mcp(entry.task):
 
@@ -137,12 +163,20 @@ async def _drive_task(entry: TaskEntry) -> None:
 
             if response.content and response.tool_calls:
                 entry.thinking.append(response.content.strip())
+                _emit("thinking", {"content": response.content.strip(), "task_id": entry.id})
             elif response.content:
                 output_parts.append(response.content.strip())
+                _emit("content", {"content": response.content.strip(), "task_id": entry.id})
 
             for call in response.tool_calls or []:
                 entry.tool_calls.append({
                     "id": call.id, "name": call.name, "arguments": call.arguments,
+                })
+                _emit("tool_call", {
+                    "task_id":   entry.id,
+                    "id":        call.id,
+                    "name":      call.name,
+                    "arguments": call.arguments,
                 })
 
             for result in response.tool_results or []:
@@ -152,6 +186,13 @@ async def _drive_task(entry: TaskEntry) -> None:
                     "success":      result.success,
                     "result":       result.result if result.success else None,
                     "error":        result.error  if not result.success else None,
+                })
+                _emit("tool_result", {
+                    "task_id":     entry.id,
+                    "tool_call_id":result.tool_call_id,
+                    "tool_name":   result.tool_name,
+                    "success":     result.success,
+                    "result":      result.result if result.success else result.error,
                 })
 
         if entry.status != "cancelled":
@@ -172,6 +213,12 @@ async def _drive_task(entry: TaskEntry) -> None:
     finally:
         entry.finished_at = datetime.utcnow().isoformat()
         _log("info", f"Task {entry.id} finished — status={entry.status}")
+        _emit("task_done", {
+            "task_id": entry.id,
+            "status":  entry.status,
+            "result":  entry.result,
+            "error":   entry.error,
+        })
 
 
 def _create_task(task: str, agent: "PentestAgentAgent", target: Optional[str], scope: list[str]) -> TaskEntry:

--- a/pentestagent/mcp/server/mcp_transport_stdio.py
+++ b/pentestagent/mcp/server/mcp_transport_stdio.py
@@ -27,3 +27,54 @@ async def run_stdio(router: MCPRouter):
         response = await router.handle(req)
         if response is not None:
             _send(response)
+
+
+async def run_stdio_fifo(router: MCPRouter, fifo_in: str, fifo_out: str):
+    """Read JSON-RPC from *fifo_in*, write responses to *fifo_out*.
+
+    Used when the MCP server runs alongside a TUI in a terminal window.
+    The child opens *fifo_in* for reading (MCP requests come in from the
+    parent) and *fifo_out* for writing (MCP responses go out to the parent).
+
+    Opening order is intentional to match the parent's FifoTransport which
+    opens them in the opposite direction concurrently:
+      child  opens fifo_in  O_RDONLY → parent thread unblocks O_WRONLY
+      child  opens fifo_out O_WRONLY → parent thread unblocks O_RDONLY
+    """
+    loop = asyncio.get_event_loop()
+
+    # Sequential opens are safe here: the parent opens both ends concurrently
+    # (via asyncio.gather + executor), so the child's sequential opens will
+    # pair with the waiting parent threads.
+    in_file = await loop.run_in_executor(
+        None, lambda: open(fifo_in, "r", buffering=1)
+    )
+    out_file = await loop.run_in_executor(
+        None, lambda: open(fifo_out, "w", buffering=1)
+    )
+
+    def _read_fifo() -> dict | None:
+        line = in_file.readline()
+        return json.loads(line.strip()) if line else None
+
+    def _send_fifo(msg: dict) -> None:
+        out_file.write(json.dumps(msg) + "\n")
+        out_file.flush()
+
+    try:
+        while True:
+            req = await loop.run_in_executor(None, _read_fifo)
+            if req is None:
+                break
+            response = await router.handle(req)
+            if response is not None:
+                await loop.run_in_executor(None, lambda r=response: _send_fifo(r))
+    finally:
+        try:
+            in_file.close()
+        except Exception:
+            pass
+        try:
+            out_file.close()
+        except Exception:
+            pass

--- a/pentestagent/mcp/transport.py
+++ b/pentestagent/mcp/transport.py
@@ -303,6 +303,104 @@ class SSETransport(MCPTransport):
             self._connected = False
 
 
+class FifoTransport(MCPTransport):
+    """MCP transport over a pair of named FIFOs.
+
+    Used when the child MCP server runs in a separate terminal window with a TUI.
+    The parent writes MCP requests to ``fifo_in`` and reads responses from
+    ``fifo_out``.  The child does the opposite: reads from ``fifo_in``, writes
+    to ``fifo_out``.
+
+    FIFO open(2) calls block until the other end is also opened, so the two
+    opens are issued concurrently (via asyncio gather + executor threads) to
+    avoid deadlock.  The parent waits up to *connect_timeout* seconds for the
+    child process to start and open its end.
+    """
+
+    def __init__(self, fifo_in: str, fifo_out: str, connect_timeout: float = 30.0):
+        self.fifo_in = fifo_in      # parent writes, child reads
+        self.fifo_out = fifo_out    # child writes, parent reads
+        self._writer = None
+        self._reader = None
+        self._connected = False
+        self._lock = asyncio.Lock()
+        self._connect_timeout = connect_timeout
+        self.logs = ""
+
+    def get_logs(self) -> str:
+        return self.logs
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected
+
+    async def connect(self):
+        """Open both FIFOs concurrently.  Blocks until the child opens its ends."""
+        loop = asyncio.get_event_loop()
+
+        async def _open_write():
+            fd = await loop.run_in_executor(
+                None, lambda: os.open(self.fifo_in, os.O_WRONLY)
+            )
+            return os.fdopen(fd, "w", buffering=1)
+
+        async def _open_read():
+            fd = await loop.run_in_executor(
+                None, lambda: os.open(self.fifo_out, os.O_RDONLY)
+            )
+            return os.fdopen(fd, "r", buffering=1)
+
+        try:
+            self._writer, self._reader = await asyncio.wait_for(
+                asyncio.gather(_open_write(), _open_read()),
+                timeout=self._connect_timeout,
+            )
+            self._connected = True
+        except asyncio.TimeoutError:
+            raise RuntimeError(
+                f"Timeout ({self._connect_timeout}s) waiting for child agent "
+                "to open FIFOs — child may have failed to start"
+            )
+
+    async def send(self, message: dict, timeout: float = 15.0) -> dict:
+        if not self._writer or not self._reader:
+            raise RuntimeError("FifoTransport not connected")
+
+        async with self._lock:
+            loop = asyncio.get_event_loop()
+            msg_str = json.dumps(message) + "\n"
+
+            await loop.run_in_executor(
+                None,
+                lambda: (self._writer.write(msg_str), self._writer.flush()),
+            )
+
+            if "id" not in message:
+                return {}
+
+            try:
+                line = await asyncio.wait_for(
+                    loop.run_in_executor(None, self._reader.readline),
+                    timeout=timeout,
+                )
+                if not line:
+                    raise RuntimeError("Child closed FIFO connection")
+                return json.loads(line.strip())
+            except asyncio.TimeoutError:
+                raise RuntimeError("Timeout waiting for MCP response via FIFO")
+
+    async def disconnect(self):
+        self._connected = False
+        for f in (self._writer, self._reader):
+            if f:
+                try:
+                    f.close()
+                except Exception:
+                    pass
+        self._writer = None
+        self._reader = None
+
+
 class WebSocketTransport(MCPTransport):
     """MCP transport over WebSocket."""
 

--- a/pentestagent/tools/__init__.py
+++ b/pentestagent/tools/__init__.py
@@ -16,7 +16,7 @@ from .registry import (
     register_tool_instance,
 )
 
-from .mcp_agent import create_spawn_mcp_agent_tool
+from .mcp_agent import create_spawn_mcp_agent_tool, create_despawn_mcp_agent_tool
 
 # Auto-load all built-in tools on import
 _loaded = load_all_tools()
@@ -42,4 +42,5 @@ __all__ = [
     "reload_tools",
     "discover_tools",
     "create_spawn_mcp_agent_tool",
+    "create_despawn_mcp_agent_tool",
 ]

--- a/pentestagent/tools/mcp_agent.py
+++ b/pentestagent/tools/mcp_agent.py
@@ -238,6 +238,121 @@ def create_spawn_mcp_agent_tool(agent: "BaseAgent") -> Tool:
     )
 
 
+def create_despawn_mcp_agent_tool(agent: "BaseAgent") -> Tool:
+    """
+    Build and return the despawn_mcp_agent Tool with the agent captured in closure.
+
+    Args:
+        agent: The parent PentestAgentAgent instance whose tool list will be pruned.
+
+    Returns:
+        A fully configured Tool ready to be passed to agent.add_tools().
+    """
+
+    async def _despawn_mcp_agent(arguments: dict, runtime: "Runtime") -> str:
+        import os
+
+        from ..mcp.manager import FifoServerConfig
+
+        server_name: str = arguments.get("server_name", "").strip()
+        if not server_name:
+            return "[error] 'server_name' is required."
+
+        manager: "MCPManager" = _get_or_create_manager(runtime)
+
+        server = manager.servers.get(server_name)
+        if server is None:
+            return (
+                f"[error] No child MCP server named '{server_name}' is currently "
+                "connected. Use spawn_mcp_agent first, or check the name."
+            )
+
+        # ── Collect FIFO / tmp-dir paths before disconnect wipes them ─────────
+        fifo_paths: list[str] = []
+        tmp_dir: str = ""
+        if isinstance(server.config, FifoServerConfig):
+            fifo_paths = [server.config.fifo_in, server.config.fifo_out]
+            if fifo_paths:
+                tmp_dir = os.path.dirname(fifo_paths[0])
+
+        # ── Remove tools that belong to this server from the parent agent ─────
+        # All tools injected from a child server are named  mcp_<server_name>_*
+        prefix = f"mcp_{server_name}_"
+        tools_to_remove = [t for t in agent.tools if t.name.startswith(prefix)]
+        agent.delete_tools(tools_to_remove)
+        removed_names = [t.name for t in tools_to_remove]
+
+        # ── Terminate child process (TUI mode) ────────────────────────────────
+        child_proc = None
+        child_processes: dict = getattr(manager, "_child_processes", {})
+        if server_name in child_processes:
+            child_proc = child_processes.pop(server_name)
+            try:
+                child_proc.terminate()
+                try:
+                    await asyncio.wait_for(child_proc.wait(), timeout=5.0)
+                except asyncio.TimeoutError:
+                    child_proc.kill()
+                    await child_proc.wait()
+            except (ProcessLookupError, OSError):
+                pass  # already dead
+
+        # ── Disconnect MCP transport ──────────────────────────────────────────
+        await manager.disconnect_server(server_name)
+
+        # ── Clean up FIFOs and temp directory ────────────────────────────────
+        for path in fifo_paths:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+        if tmp_dir:
+            try:
+                os.rmdir(tmp_dir)
+            except OSError:
+                pass
+
+        # ── Build result summary ──────────────────────────────────────────────
+        lines = [
+            f"[ok] Child MCP agent '{server_name}' has been despawned.",
+            f"process terminated: {'yes' if child_proc is not None else 'n/a (headless)'}",
+            f"transport closed:   yes",
+            f"tools removed ({len(removed_names)}): {', '.join(removed_names) or 'none'}",
+            f"fifo cleanup:       {'yes' if fifo_paths else 'n/a'}",
+        ]
+        return "\n".join(lines)
+
+    return Tool(
+        name="despawn_mcp_agent",
+        description=(
+            "Terminate a child MCP agent that was previously spawned with "
+            "spawn_mcp_agent and free all associated resources. "
+            "This will: (1) send SIGTERM (then SIGKILL if needed) to the child "
+            "process; (2) close the MCP transport connection; (3) remove all tools "
+            "that the child injected into your tool set; (4) delete any FIFO files "
+            "and temporary directories created for TUI mode. "
+            "Use this when a subtask is complete and you no longer need the child "
+            "agent, or when you want to reclaim resources. "
+            "Pass the server_name that was returned by spawn_mcp_agent."
+        ),
+        schema=ToolSchema(
+            properties={
+                "server_name": {
+                    "type": "string",
+                    "description": (
+                        "The server name of the child agent to despawn "
+                        "(e.g. 'child_agent_1'). This is the 'server_name' field "
+                        "returned by spawn_mcp_agent."
+                    ),
+                },
+            },
+            required=["server_name"],
+        ),
+        execute_fn=_despawn_mcp_agent,
+        category="agents",
+    )
+
+
 def _get_or_create_manager(runtime: "Runtime") -> "MCPManager":
     from ..mcp.manager import MCPManager
 

--- a/pentestagent/tools/mcp_agent.py
+++ b/pentestagent/tools/mcp_agent.py
@@ -312,6 +312,13 @@ def create_despawn_mcp_agent_tool(agent: "BaseAgent") -> Tool:
             except OSError:
                 pass
 
+        # ── Remove terminal from TUI (no-op in headless mode) ────────────────
+        try:
+            from ..interface.notifier import despawn_terminal
+            despawn_terminal(server_name)
+        except Exception:
+            pass
+
         # ── Build result summary ──────────────────────────────────────────────
         lines = [
             f"[ok] Child MCP agent '{server_name}' has been despawned.",

--- a/pentestagent/tools/mcp_agent.py
+++ b/pentestagent/tools/mcp_agent.py
@@ -1,9 +1,10 @@
+import asyncio
+import fcntl
 import os
-import shlex
-import shutil
-import subprocess
+import struct
 import sys
 import tempfile
+import termios
 from typing import TYPE_CHECKING
 
 from .registry import Tool, ToolSchema
@@ -12,48 +13,6 @@ if TYPE_CHECKING:
     from ..agents.base_agent import BaseAgent
     from ..mcp.manager import MCPManager
     from ..runtime import Runtime
-
-
-# ── Terminal helpers ──────────────────────────────────────────────────────────
-
-def _find_terminal() -> str | None:
-    """Return the name of an available terminal emulator, or None."""
-    for t in ("gnome-terminal", "xterm", "konsole", "alacritty", "kitty",
-              "xfce4-terminal", "lxterminal", "tilix", "terminator"):
-        if shutil.which(t):
-            return t
-    return None
-
-
-def _build_terminal_argv(terminal: str, cmd: list[str]) -> list[str]:
-    """Wrap *cmd* with the terminal-emulator's invocation syntax."""
-    if terminal == "gnome-terminal":
-        # gnome-terminal forks the child itself; use -- to separate its own
-        # flags from the command.
-        return ["gnome-terminal", "--"] + cmd
-    elif terminal in ("konsole",):
-        return ["konsole", "-e"] + cmd
-    elif terminal in ("alacritty",):
-        return ["alacritty", "-e"] + cmd
-    elif terminal == "kitty":
-        return ["kitty"] + cmd
-    elif terminal in ("xfce4-terminal", "lxterminal", "tilix", "terminator"):
-        # These accept -e with a single shell string
-        return [terminal, "-e", " ".join(shlex.quote(c) for c in cmd)]
-    else:
-        # xterm and most others: -e followed by argv
-        return [terminal, "-e"] + cmd
-
-
-def _launch_in_terminal(cmd: list[str], terminal: str | None = None) -> bool:
-    """Launch *cmd* in a new terminal window.  Returns True on success."""
-    t = terminal or _find_terminal()
-    if not t:
-        return False
-    argv = _build_terminal_argv(t, cmd)
-    subprocess.Popen(argv, start_new_session=True,
-                     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-    return True
 
 
 def create_spawn_mcp_agent_tool(agent: "BaseAgent") -> Tool:
@@ -102,30 +61,39 @@ def create_spawn_mcp_agent_tool(agent: "BaseAgent") -> Tool:
         if no_mcp:
             cmd_args.append("--no-mcp")
 
-        # ── TUI mode: launch in a new terminal window via named FIFOs ─────────
+        # ── TUI mode: PTY + FIFOs, embedded terminal in parent TUI ──────────────
         if tui:
-            # Check terminal availability before creating FIFOs
-            term = _find_terminal()
-            if term is None:
-                tui = False  # fall back to headless silently
+            from ..interface.notifier import spawn_terminal
 
-        if tui:
             tmp_dir = tempfile.mkdtemp(prefix="pa_mcp_")
             fifo_in  = os.path.join(tmp_dir, "mcp_in.fifo")
             fifo_out = os.path.join(tmp_dir, "mcp_out.fifo")
             os.mkfifo(fifo_in)
             os.mkfifo(fifo_out)
 
-            tui_cmd_args = cmd_args + [
+            # Create a PTY pair: child uses slave as its terminal (TUI renders
+            # there), parent reads from master to display in EmbeddedTerminal.
+            master_fd, slave_fd = os.openpty()
+
+            # Give the slave a sensible initial size (widget will TIOCSWINSZ later)
+            fcntl.ioctl(slave_fd, termios.TIOCSWINSZ,
+                        struct.pack("HHHH", 24, 80, 0, 0))
+
+            tui_cmd_args = ["-m", "pentestagent"] + cmd_args + [
                 "--tui",
                 "--mcp-fifo-in",  fifo_in,
                 "--mcp-fifo-out", fifo_out,
             ]
-            child_argv = [sys.executable, "-m", "pentestagent"] + tui_cmd_args
-
-            launched = _launch_in_terminal(child_argv, terminal=term)  # term already resolved
-            if not launched:
-                # Clean up FIFOs and fall back to headless
+            try:
+                child_proc = await asyncio.create_subprocess_exec(
+                    sys.executable, *tui_cmd_args,
+                    stdin=slave_fd,
+                    stdout=slave_fd,
+                    stderr=slave_fd,
+                )
+            except Exception as exc:
+                os.close(slave_fd)
+                os.close(master_fd)
                 for p in (fifo_in, fifo_out):
                     try:
                         os.unlink(p)
@@ -135,17 +103,30 @@ def create_spawn_mcp_agent_tool(agent: "BaseAgent") -> Tool:
                     os.rmdir(tmp_dir)
                 except OSError:
                     pass
-                tui = False
+                return f"[error] Failed to launch TUI child: {exc}"
 
-            if tui:
-                config = FifoServerConfig(
-                    name=server_name,
-                    fifo_in=fifo_in,
-                    fifo_out=fifo_out,
-                    description=(
-                        f"Child PentestAgent TUI (target={target or 'none'})"
-                    ),
-                )
+            os.close(slave_fd)  # slave only needed in the child
+
+            # Keep a reference so the process isn't garbage-collected and so
+            # the manager can terminate it on disconnect.
+            if not hasattr(manager, "_child_processes"):
+                manager._child_processes = {}  # type: ignore[attr-defined]
+            manager._child_processes[server_name] = child_proc  # type: ignore[attr-defined]
+
+            # Ask the parent TUI to open an EmbeddedTerminal for this PTY.
+            # If no TUI is active (headless parent), fall back gracefully.
+            tui_accepted = spawn_terminal(master_fd, server_name)
+            if not tui_accepted:
+                # No TUI available — close PTY, child output will be lost but
+                # MCP still works via FIFOs.
+                os.close(master_fd)
+
+            config = FifoServerConfig(
+                name=server_name,
+                fifo_in=fifo_in,
+                fifo_out=fifo_out,
+                description=f"Child PentestAgent TUI (target={target or 'none'})",
+            )
 
         # ── Headless mode: direct subprocess via stdin/stdout pipes ───────────
         if not tui:
@@ -171,7 +152,7 @@ def create_spawn_mcp_agent_tool(agent: "BaseAgent") -> Tool:
 
         tool_names = [t.name for t in child_tools]
 
-        mode_label = "TUI (new terminal)" if tui else "headless (stdio)"
+        mode_label = "TUI (embedded)" if tui else "headless (stdio)"
         lines = [
             f"[ok] Child MCP agent spawned ({mode_label}).",
             f"server_name: {server_name}",
@@ -189,9 +170,10 @@ def create_spawn_mcp_agent_tool(agent: "BaseAgent") -> Tool:
         description=(
             "Spawn a child PentestAgent process as a subordinate MCP server and "
             "register its tools into your current tool set. "
-            "By default (tui=true) the child is launched in a new terminal window "
-            "so an operator can observe it via the TUI; MCP communication is "
-            "transparently routed through named FIFOs. "
+            "By default (tui=true) the child is launched with an embedded terminal "
+            "panel inside the parent TUI so an operator can observe it; MCP "
+            "communication is routed through named FIFOs while the child's TUI "
+            "output is captured via PTY and rendered in a side panel. "
             "Set tui=false for a fully headless child that communicates over "
             "stdin/stdout pipes with no visible window. "
             "After this tool returns, the child's tools (run_task, spawn_agent, "

--- a/pentestagent/tools/mcp_agent.py
+++ b/pentestagent/tools/mcp_agent.py
@@ -84,12 +84,20 @@ def create_spawn_mcp_agent_tool(agent: "BaseAgent") -> Tool:
                 "--mcp-fifo-in",  fifo_in,
                 "--mcp-fifo-out", fifo_out,
             ]
+            child_env = {**os.environ, "TERM": "xterm-256color", "COLORTERM": "truecolor"}
+
+            def _child_pty_setup() -> None:
+                os.setsid()
+                fcntl.ioctl(0, termios.TIOCSCTTY, 0)
+
             try:
                 child_proc = await asyncio.create_subprocess_exec(
                     sys.executable, *tui_cmd_args,
                     stdin=slave_fd,
                     stdout=slave_fd,
                     stderr=slave_fd,
+                    env=child_env,
+                    preexec_fn=_child_pty_setup,
                 )
             except Exception as exc:
                 os.close(slave_fd)

--- a/pentestagent/tools/mcp_agent.py
+++ b/pentestagent/tools/mcp_agent.py
@@ -1,4 +1,9 @@
+import os
+import shlex
+import shutil
+import subprocess
 import sys
+import tempfile
 from typing import TYPE_CHECKING
 
 from .registry import Tool, ToolSchema
@@ -7,6 +12,48 @@ if TYPE_CHECKING:
     from ..agents.base_agent import BaseAgent
     from ..mcp.manager import MCPManager
     from ..runtime import Runtime
+
+
+# ── Terminal helpers ──────────────────────────────────────────────────────────
+
+def _find_terminal() -> str | None:
+    """Return the name of an available terminal emulator, or None."""
+    for t in ("gnome-terminal", "xterm", "konsole", "alacritty", "kitty",
+              "xfce4-terminal", "lxterminal", "tilix", "terminator"):
+        if shutil.which(t):
+            return t
+    return None
+
+
+def _build_terminal_argv(terminal: str, cmd: list[str]) -> list[str]:
+    """Wrap *cmd* with the terminal-emulator's invocation syntax."""
+    if terminal == "gnome-terminal":
+        # gnome-terminal forks the child itself; use -- to separate its own
+        # flags from the command.
+        return ["gnome-terminal", "--"] + cmd
+    elif terminal in ("konsole",):
+        return ["konsole", "-e"] + cmd
+    elif terminal in ("alacritty",):
+        return ["alacritty", "-e"] + cmd
+    elif terminal == "kitty":
+        return ["kitty"] + cmd
+    elif terminal in ("xfce4-terminal", "lxterminal", "tilix", "terminator"):
+        # These accept -e with a single shell string
+        return [terminal, "-e", " ".join(shlex.quote(c) for c in cmd)]
+    else:
+        # xterm and most others: -e followed by argv
+        return [terminal, "-e"] + cmd
+
+
+def _launch_in_terminal(cmd: list[str], terminal: str | None = None) -> bool:
+    """Launch *cmd* in a new terminal window.  Returns True on success."""
+    t = terminal or _find_terminal()
+    if not t:
+        return False
+    argv = _build_terminal_argv(t, cmd)
+    subprocess.Popen(argv, start_new_session=True,
+                     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    return True
 
 
 def create_spawn_mcp_agent_tool(agent: "BaseAgent") -> Tool:
@@ -22,13 +69,14 @@ def create_spawn_mcp_agent_tool(agent: "BaseAgent") -> Tool:
     """
 
     async def _spawn_mcp_agent(arguments: dict, runtime: "Runtime") -> str:
-        from ..mcp.manager import MCPManager, StdioServerConfig
+        from ..mcp.manager import MCPManager, FifoServerConfig, StdioServerConfig
 
         target      = arguments.get("target", "")
         scope: list = arguments.get("scope", [])
         model       = arguments.get("model", "")
         no_rag      = bool(arguments.get("no_rag", False))
         no_mcp      = bool(arguments.get("no_mcp", True))
+        tui         = bool(arguments.get("tui", True))
 
         # ── Auto-generate a unique server name — not exposed to the LLM ──────
         manager: MCPManager = _get_or_create_manager(runtime)
@@ -37,13 +85,11 @@ def create_spawn_mcp_agent_tool(agent: "BaseAgent") -> Tool:
         ) + 1
         server_name = f"child_agent_{child_index}"
 
-        # Safety: increment until we find a free slot (handles gaps from
-        # disconnected servers that were removed from manager.servers)
         while server_name in manager.servers:
             child_index += 1
             server_name = f"child_agent_{child_index}"
 
-        # ── Build the child command ───────────────────────────────────────────
+        # ── Build the child command args (common) ─────────────────────────────
         cmd_args = ["mcp_server", "--type", "stdio"]
         if target:
             cmd_args += ["--target", target]
@@ -56,13 +102,60 @@ def create_spawn_mcp_agent_tool(agent: "BaseAgent") -> Tool:
         if no_mcp:
             cmd_args.append("--no-mcp")
 
-        config = StdioServerConfig(
-            name=server_name,
-            command=sys.executable,
-            args=["-m", "pentestagent"] + cmd_args,
-            env={},
-            description=f"Child PentestAgent (target={target or 'none'})",
-        )
+        # ── TUI mode: launch in a new terminal window via named FIFOs ─────────
+        if tui:
+            # Check terminal availability before creating FIFOs
+            term = _find_terminal()
+            if term is None:
+                tui = False  # fall back to headless silently
+
+        if tui:
+            tmp_dir = tempfile.mkdtemp(prefix="pa_mcp_")
+            fifo_in  = os.path.join(tmp_dir, "mcp_in.fifo")
+            fifo_out = os.path.join(tmp_dir, "mcp_out.fifo")
+            os.mkfifo(fifo_in)
+            os.mkfifo(fifo_out)
+
+            tui_cmd_args = cmd_args + [
+                "--tui",
+                "--mcp-fifo-in",  fifo_in,
+                "--mcp-fifo-out", fifo_out,
+            ]
+            child_argv = [sys.executable, "-m", "pentestagent"] + tui_cmd_args
+
+            launched = _launch_in_terminal(child_argv, terminal=term)  # term already resolved
+            if not launched:
+                # Clean up FIFOs and fall back to headless
+                for p in (fifo_in, fifo_out):
+                    try:
+                        os.unlink(p)
+                    except OSError:
+                        pass
+                try:
+                    os.rmdir(tmp_dir)
+                except OSError:
+                    pass
+                tui = False
+
+            if tui:
+                config = FifoServerConfig(
+                    name=server_name,
+                    fifo_in=fifo_in,
+                    fifo_out=fifo_out,
+                    description=(
+                        f"Child PentestAgent TUI (target={target or 'none'})"
+                    ),
+                )
+
+        # ── Headless mode: direct subprocess via stdin/stdout pipes ───────────
+        if not tui:
+            config = StdioServerConfig(
+                name=server_name,
+                command=sys.executable,
+                args=["-m", "pentestagent"] + cmd_args,
+                env={},
+                description=f"Child PentestAgent (target={target or 'none'})",
+            )
 
         # ── Connect ───────────────────────────────────────────────────────────
         server = await manager._connect_server(config)
@@ -78,9 +171,9 @@ def create_spawn_mcp_agent_tool(agent: "BaseAgent") -> Tool:
 
         tool_names = [t.name for t in child_tools]
 
-        # ── Result ────────────────────────────────────────────────────────────
+        mode_label = "TUI (new terminal)" if tui else "headless (stdio)"
         lines = [
-            f"[ok] Child MCP agent spawned.",
+            f"[ok] Child MCP agent spawned ({mode_label}).",
             f"server_name: {server_name}",
             f"target:      {target or 'none'}",
             f"scope:       {scope or []}",
@@ -94,8 +187,13 @@ def create_spawn_mcp_agent_tool(agent: "BaseAgent") -> Tool:
     return Tool(
         name="spawn_mcp_agent",
         description=(
-            "Spawn a child PentestAgent process as a subordinate MCP server over stdio "
-            "and register its tools into your current tool set. "
+            "Spawn a child PentestAgent process as a subordinate MCP server and "
+            "register its tools into your current tool set. "
+            "By default (tui=true) the child is launched in a new terminal window "
+            "so an operator can observe it via the TUI; MCP communication is "
+            "transparently routed through named FIFOs. "
+            "Set tui=false for a fully headless child that communicates over "
+            "stdin/stdout pipes with no visible window. "
             "After this tool returns, the child's tools (run_task, spawn_agent, "
             "await_agents, etc.) will be available to you in the NEXT tool call — "
             "they are not usable within the same turn. "
@@ -130,6 +228,16 @@ def create_spawn_mcp_agent_tool(agent: "BaseAgent") -> Tool:
                     "description": (
                         "Skip external MCP server connections on the child "
                         "(default: true — children don't chain MCP servers unless asked)."
+                    ),
+                },
+                "tui": {
+                    "type": "boolean",
+                    "description": (
+                        "Launch the child in a new terminal window with a TUI so an "
+                        "operator can observe it (default: true). "
+                        "Set to false for a fully headless child. "
+                        "Falls back to headless automatically if no terminal emulator "
+                        "is available."
                     ),
                 },
             },

--- a/pentestagent/tools/mcp_agent.py
+++ b/pentestagent/tools/mcp_agent.py
@@ -28,14 +28,13 @@ def create_spawn_mcp_agent_tool(agent: "BaseAgent") -> Tool:
     """
 
     async def _spawn_mcp_agent(arguments: dict, runtime: "Runtime") -> str:
-        from ..mcp.manager import MCPManager, FifoServerConfig, StdioServerConfig
+        from ..mcp.manager import MCPManager, FifoServerConfig
 
         target      = arguments.get("target", "")
         scope: list = arguments.get("scope", [])
         model       = arguments.get("model", "")
         no_rag      = bool(arguments.get("no_rag", False))
         no_mcp      = bool(arguments.get("no_mcp", True))
-        tui         = bool(arguments.get("tui", True))
 
         # ── Auto-generate a unique server name — not exposed to the LLM ──────
         manager: MCPManager = _get_or_create_manager(runtime)
@@ -62,89 +61,78 @@ def create_spawn_mcp_agent_tool(agent: "BaseAgent") -> Tool:
             cmd_args.append("--no-mcp")
 
         # ── TUI mode: PTY + FIFOs, embedded terminal in parent TUI ──────────────
-        if tui:
-            from ..interface.notifier import spawn_terminal
+        from ..interface.notifier import spawn_terminal
 
-            tmp_dir = tempfile.mkdtemp(prefix="pa_mcp_")
-            fifo_in  = os.path.join(tmp_dir, "mcp_in.fifo")
-            fifo_out = os.path.join(tmp_dir, "mcp_out.fifo")
-            os.mkfifo(fifo_in)
-            os.mkfifo(fifo_out)
+        tmp_dir = tempfile.mkdtemp(prefix="pa_mcp_")
+        fifo_in  = os.path.join(tmp_dir, "mcp_in.fifo")
+        fifo_out = os.path.join(tmp_dir, "mcp_out.fifo")
+        os.mkfifo(fifo_in)
+        os.mkfifo(fifo_out)
 
-            # Create a PTY pair: child uses slave as its terminal (TUI renders
-            # there), parent reads from master to display in EmbeddedTerminal.
-            master_fd, slave_fd = os.openpty()
+        # Create a PTY pair: child uses slave as its terminal (TUI renders
+        # there), parent reads from master to display in EmbeddedTerminal.
+        master_fd, slave_fd = os.openpty()
 
-            # Give the slave a sensible initial size (widget will TIOCSWINSZ later)
-            fcntl.ioctl(slave_fd, termios.TIOCSWINSZ,
-                        struct.pack("HHHH", 24, 80, 0, 0))
+        # Give the slave a sensible initial size (widget will TIOCSWINSZ later)
+        fcntl.ioctl(slave_fd, termios.TIOCSWINSZ,
+                    struct.pack("HHHH", 24, 80, 0, 0))
 
-            tui_cmd_args = ["-m", "pentestagent"] + cmd_args + [
-                "--tui",
-                "--mcp-fifo-in",  fifo_in,
-                "--mcp-fifo-out", fifo_out,
-            ]
-            child_env = {**os.environ, "TERM": "xterm-256color", "COLORTERM": "truecolor"}
+        tui_cmd_args = ["-m", "pentestagent"] + cmd_args + [
+            "--tui",
+            "--mcp-fifo-in",  fifo_in,
+            "--mcp-fifo-out", fifo_out,
+        ]
+        child_env = {**os.environ, "TERM": "xterm-256color", "COLORTERM": "truecolor"}
 
-            def _child_pty_setup() -> None:
-                os.setsid()
-                fcntl.ioctl(0, termios.TIOCSCTTY, 0)
+        def _child_pty_setup() -> None:
+            os.setsid()
+            fcntl.ioctl(0, termios.TIOCSCTTY, 0)
 
-            try:
-                child_proc = await asyncio.create_subprocess_exec(
-                    sys.executable, *tui_cmd_args,
-                    stdin=slave_fd,
-                    stdout=slave_fd,
-                    stderr=slave_fd,
-                    env=child_env,
-                    preexec_fn=_child_pty_setup,
-                )
-            except Exception as exc:
-                os.close(slave_fd)
-                os.close(master_fd)
-                for p in (fifo_in, fifo_out):
-                    try:
-                        os.unlink(p)
-                    except OSError:
-                        pass
+        try:
+            child_proc = await asyncio.create_subprocess_exec(
+                sys.executable, *tui_cmd_args,
+                stdin=slave_fd,
+                stdout=slave_fd,
+                stderr=slave_fd,
+                env=child_env,
+                preexec_fn=_child_pty_setup,
+            )
+        except Exception as exc:
+            os.close(slave_fd)
+            os.close(master_fd)
+            for p in (fifo_in, fifo_out):
                 try:
-                    os.rmdir(tmp_dir)
+                    os.unlink(p)
                 except OSError:
                     pass
-                return f"[error] Failed to launch TUI child: {exc}"
+            try:
+                os.rmdir(tmp_dir)
+            except OSError:
+                pass
+            return f"[error] Failed to launch TUI child: {exc}"
 
-            os.close(slave_fd)  # slave only needed in the child
+        os.close(slave_fd)  # slave only needed in the child
 
-            # Keep a reference so the process isn't garbage-collected and so
-            # the manager can terminate it on disconnect.
-            if not hasattr(manager, "_child_processes"):
-                manager._child_processes = {}  # type: ignore[attr-defined]
-            manager._child_processes[server_name] = child_proc  # type: ignore[attr-defined]
+        # Keep a reference so the process isn't garbage-collected and so
+        # the manager can terminate it on disconnect.
+        if not hasattr(manager, "_child_processes"):
+            manager._child_processes = {}  # type: ignore[attr-defined]
+        manager._child_processes[server_name] = child_proc  # type: ignore[attr-defined]
 
-            # Ask the parent TUI to open an EmbeddedTerminal for this PTY.
-            # If no TUI is active (headless parent), fall back gracefully.
-            tui_accepted = spawn_terminal(master_fd, server_name)
-            if not tui_accepted:
-                # No TUI available — close PTY, child output will be lost but
-                # MCP still works via FIFOs.
-                os.close(master_fd)
+        # Ask the parent TUI to open an EmbeddedTerminal for this PTY.
+        # If no TUI is active (headless parent), fall back gracefully.
+        tui_accepted = spawn_terminal(master_fd, server_name)
+        if not tui_accepted:
+            # No TUI available — close PTY, child output will be lost but
+            # MCP still works via FIFOs.
+            os.close(master_fd)
 
-            config = FifoServerConfig(
-                name=server_name,
-                fifo_in=fifo_in,
-                fifo_out=fifo_out,
-                description=f"Child PentestAgent TUI (target={target or 'none'})",
-            )
-
-        # ── Headless mode: direct subprocess via stdin/stdout pipes ───────────
-        if not tui:
-            config = StdioServerConfig(
-                name=server_name,
-                command=sys.executable,
-                args=["-m", "pentestagent"] + cmd_args,
-                env={},
-                description=f"Child PentestAgent (target={target or 'none'})",
-            )
+        config = FifoServerConfig(
+            name=server_name,
+            fifo_in=fifo_in,
+            fifo_out=fifo_out,
+            description=f"Child PentestAgent TUI (target={target or 'none'})",
+        )
 
         # ── Connect ───────────────────────────────────────────────────────────
         server = await manager._connect_server(config)
@@ -160,9 +148,8 @@ def create_spawn_mcp_agent_tool(agent: "BaseAgent") -> Tool:
 
         tool_names = [t.name for t in child_tools]
 
-        mode_label = "TUI (embedded)" if tui else "headless (stdio)"
         lines = [
-            f"[ok] Child MCP agent spawned ({mode_label}).",
+            "[ok] Child MCP agent spawned (TUI embedded).",
             f"server_name: {server_name}",
             f"target:      {target or 'none'}",
             f"scope:       {scope or []}",
@@ -178,12 +165,10 @@ def create_spawn_mcp_agent_tool(agent: "BaseAgent") -> Tool:
         description=(
             "Spawn a child PentestAgent process as a subordinate MCP server and "
             "register its tools into your current tool set. "
-            "By default (tui=true) the child is launched with an embedded terminal "
-            "panel inside the parent TUI so an operator can observe it; MCP "
-            "communication is routed through named FIFOs while the child's TUI "
-            "output is captured via PTY and rendered in a side panel. "
-            "Set tui=false for a fully headless child that communicates over "
-            "stdin/stdout pipes with no visible window. "
+            "The child is always launched with an embedded terminal panel inside the "
+            "parent TUI so an operator can observe it; MCP communication is routed "
+            "through named FIFOs while the child's TUI output is captured via PTY "
+            "and rendered in a side panel. "
             "After this tool returns, the child's tools (run_task, spawn_agent, "
             "await_agents, etc.) will be available to you in the NEXT tool call — "
             "they are not usable within the same turn. "
@@ -218,16 +203,6 @@ def create_spawn_mcp_agent_tool(agent: "BaseAgent") -> Tool:
                     "description": (
                         "Skip external MCP server connections on the child "
                         "(default: true — children don't chain MCP servers unless asked)."
-                    ),
-                },
-                "tui": {
-                    "type": "boolean",
-                    "description": (
-                        "Launch the child in a new terminal window with a TUI so an "
-                        "operator can observe it (default: true). "
-                        "Set to false for a fully headless child. "
-                        "Falls back to headless automatically if no terminal emulator "
-                        "is available."
                     ),
                 },
             },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "pyyaml>=6.0.0",
     "jinja2>=3.1.0",
+    "pyte>=0.8.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ rich>=13.7.0
 textual>=0.63.0
 typer>=0.12.0
 pyperclip>=1.11.0
+pyte>=0.8.0
 
 
 # Config


### PR DESCRIPTION
Add despawn_mcp_agent tool to cleanly free child agent processes, transports, injected tools, and FIFO temp files
Embed child-agent TUIs inside the parent via PTY + pyte VT100 emulator widget (EmbeddedTerminal), replacing the previous external window approach
Add FIFO-based stdio transport (FifoTransport / FifoServerConfig) so MCP communication flows through named pipes while the child runs a full interactive TUI
Make spawn_mcp_agent always use interactive TUI mode (drop the tui parameter and headless fallback)
Wrap EmbeddedTerminal in CollapsibleTerminal widget — click the header to fold/unfold; collapsed panels are skipped by Textual's renderer
Add ResizeDivider — a draggable vertical bar between chat area and agents panel (min 20 cols, hover/drag color feedback, auto-hidden when no child agents are active)
Forward keyboard (VT100/xterm sequences) and mouse events (SGR protocol) from parent TUI to child PTY for full interactivity
Add --tui flag to mcp_server SSE subcommand: launches a read-only TUI observation mode alongside the server
Extract shared build_agent_components() into interface/initializer.py, eliminating ~150 lines of duplicated RAG/runtime/LLM/tools/agent setup between TUI and MCP server paths
Add MCPTaskEvent Textual message + handler to safely deliver MCP task events via the message queue (fixes NoMatches race and notify feedback loop)
Fix several PTY/mouse bugs: click coordinate offset, capture_mouse() on drag, select-based PTY reader replacing unreliable add_reader on Linux, SGR mouse reporting via TERM=xterm-256color + setsid/TIOCSCTTY
Fix agent loop: break on finish_reason=length, fix summary generation passing tools=[], untrack mcp_servers.json
Add CLAUDE.md with full project context

<img width="1235" height="549" alt="imagen" src="https://github.com/user-attachments/assets/9743d1e3-41bb-445f-9c0d-a508819ce123" />
