### PR TITLE
feat: ARM64 Docker support + fix Anthropic model compatibility

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,3 +85,37 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LOWER }}:kali
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  build-kali-arm64:
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Set lowercase image name
+        run: echo "IMAGE_NAME_LOWER=${IMAGE_NAME,,}" >> $GITHUB_ENV
+
+      - name: Build and push Kali ARM64 image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.kali
+          push: true
+          platforms: linux/arm64
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LOWER }}:kali-arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile.kali
+++ b/Dockerfile.kali
@@ -11,6 +11,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
+# Prevent post-install scripts from trying to start services inside the container
+RUN printf '#!/bin/sh\nexit 101\n' > /usr/sbin/policy-rc.d && chmod +x /usr/sbin/policy-rc.d
+
 # Update and install Kali tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
     # Python (python3-full includes venv with ensurepip)
@@ -50,7 +53,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     jq \
     xclip \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -f /usr/sbin/policy-rc.d
 
 # Create app directory
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,31 @@ services:
     profiles:
       - kali
 
+  pentestagent-kali-arm64:
+    build:
+      context: .
+      dockerfile: Dockerfile.kali
+    container_name: pentestagent-kali-arm64
+    privileged: true
+    cap_add:
+      - NET_ADMIN
+      - SYS_ADMIN
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - PENTESTAGENT_MODEL=${PENTESTAGENT_MODEL}
+      - ENABLE_TOR=${ENABLE_TOR:-false}
+      - INIT_METASPLOIT=${INIT_METASPLOIT:-false}
+      - EXPOSE_MSF_RPC=${EXPOSE_MSF_RPC:-false}
+    volumes:
+      - ./loot:/app/loot
+    networks:
+      - pentestagent-net
+    stdin_open: true
+    tty: true
+    profiles:
+      - kali-arm64
+
 networks:
   pentestagent-net:
     driver: bridge

--- a/pentestagent/llm/llm.py
+++ b/pentestagent/llm/llm.py
@@ -86,6 +86,19 @@ class LLM:
                 "Install with: pip install litellm"
             ) from e
 
+    def _is_anthropic_model(self) -> bool:
+        """Check if the current model is an Anthropic/Claude model."""
+        model_lower = self.model.lower()
+        return "claude" in model_lower or "anthropic" in model_lower
+
+    def _sanitize_messages_for_anthropic(self, messages: list) -> list:
+        """Ensure messages don't end with an assistant message (Anthropic rejects prefill)."""
+        if not self._is_anthropic_model() or not messages:
+            return messages
+        while messages and messages[-1].get("role") == "assistant":
+            messages = messages[:-1]
+        return messages
+
     def _is_rate_limit_error(self, error: Exception) -> bool:
         """Check if an error is a rate limit error."""
         error_str = str(error).lower()
@@ -153,6 +166,9 @@ class LLM:
         )
         llm_messages.extend(history)
 
+        # Anthropic rejects conversations ending with assistant messages
+        llm_messages = self._sanitize_messages_for_anthropic(llm_messages)
+
         # Build tools list
         llm_tools = None
         if tools:
@@ -164,9 +180,12 @@ class LLM:
             call_kwargs = {
                 "model": self.model,
                 "messages": llm_messages,
-                "temperature": self.config.temperature,
                 "max_tokens": max_tokens if max_tokens is not None else self.config.max_tokens,
             }
+
+            # Newer Anthropic models don't support temperature
+            if not self._is_anthropic_model():
+                call_kwargs["temperature"] = self.config.temperature
 
             # Only include tools if they exist (Anthropic requires tools param to be omitted, not None/empty)
             if llm_tools:
@@ -262,19 +281,27 @@ class LLM:
         )
         llm_messages.extend(history)
 
+        # Anthropic rejects conversations ending with assistant messages
+        llm_messages = self._sanitize_messages_for_anthropic(llm_messages)
+
         llm_tools = None
         if tools:
             llm_tools = [tool.to_llm_format() for tool in tools if tool.enabled]
 
         try:
-            response = await self._litellm.acompletion(
-                model=self.model,
-                messages=llm_messages,
-                tools=llm_tools,
-                temperature=self.config.temperature,
-                max_tokens=self.config.max_tokens,
-                stream=True,
-            )
+            stream_kwargs = {
+                "model": self.model,
+                "messages": llm_messages,
+                "tools": llm_tools,
+                "max_tokens": self.config.max_tokens,
+                "stream": True,
+            }
+
+            # Newer Anthropic models don't support temperature
+            if not self._is_anthropic_model():
+                stream_kwargs["temperature"] = self.config.temperature
+
+            response = await self._litellm.acompletion(**stream_kwargs)
 
             async for chunk in response:
                 if chunk.choices[0].delta.content:
@@ -324,18 +351,23 @@ class LLM:
             Summary text
         """
         try:
-            response = await self._litellm.acompletion(
-                model=self.model,
-                messages=[
+            summarize_kwargs = {
+                "model": self.model,
+                "messages": [
                     {
                         "role": "system",
                         "content": "You are a terse summarizer for a pentesting agent.",
                     },
                     {"role": "user", "content": prompt},
                 ],
-                temperature=0.3,  # Lower temperature for consistent summaries
-                max_tokens=1000,  # Summaries should be concise
-            )
+                "max_tokens": 1000,  # Summaries should be concise
+            }
+
+            # Newer Anthropic models don't support temperature
+            if not self._is_anthropic_model():
+                summarize_kwargs["temperature"] = 0.3
+
+            response = await self._litellm.acompletion(**summarize_kwargs)
             return response.choices[0].message.content or ""
         except Exception as e:
             return f"[Summarization failed: {e}]"


### PR DESCRIPTION
## Changes

### 1. ARM64 (Raspberry Pi) Docker support

- Add `build-kali-arm64` CI job using GitHub's native `ubuntu-24.04-arm` runner (no QEMU)
- Reuse existing `Dockerfile.kali` — all packages (including `burpsuite`, `zaproxy`, `kali-tools-*`) are available on ARM64
- Add `policy-rc.d` workaround to `Dockerfile.kali` to prevent service startup during build (Docker best practice, benefits both architectures)
- Add `pentestagent-kali-arm64` service in `docker-compose.yml` (profile: `kali-arm64`)
- Image published as `ghcr.io/<owner>/pentestagent:kali-arm64`

**Tested**: Built via CI, pulled and ran on Raspberry Pi 4 (aarch64) — all tools verified (nmap, metasploit, sqlmap, nikto, gobuster, hydra, john, hashcat, ffuf, nuclei, wpscan).

### 2. Fix Anthropic model compatibility

Newer Anthropic models reject `temperature` and assistant message prefill:

- Add `_is_anthropic_model()` helper to detect Claude/Anthropic models
- Skip `temperature` parameter in `generate()`, `generate_stream()`, and `_summarize_call()` for Anthropic models
- Add `_sanitize_messages_for_anthropic()` to strip trailing assistant messages before API calls (Anthropic requires conversation to end with a user message)
- Other providers (OpenAI, Ollama, etc.) are unaffected

### Usage

```bash
# Pull pre-built ARM64 image on Raspberry Pi
docker pull ghcr.io/<owner>/pentestagent:kali-arm64

# Or via docker-compose
docker compose --profile kali-arm64 run --rm pentestagent-kali-arm64
```