### PR TITLE
feat(tui): Slash command autocomplete with hierarchical multi-level suggestions

### DIFF
--- a/pentestagent/interface/tui.py
+++ b/pentestagent/interface/tui.py
@@ -240,7 +240,8 @@ class CommandSuggestions(Widget):
         self._highlight()
 
     def _highlight(self) -> None:
-        for i, child in enumerate(self.children):
+        children = list(self.children)
+        for i, child in enumerate(children[: len(self._matches)]):
             if i == self._selected:
                 child.add_class("--selected")
             else:
@@ -2058,6 +2059,16 @@ class PentestAgentTUI(App):
         opacity: 0.5;
     }
 
+    #tab-hint {
+        display: none;
+        width: auto;
+        height: 100%;
+        padding: 0 1;
+        color: #3a3a3a;
+        content-align-vertical: middle;
+        text-style: italic;
+    }
+
     #status-bar {
         width: 100%;
         height: 1;
@@ -2267,6 +2278,7 @@ class PentestAgentTUI(App):
                         yield Input(
                             placeholder="Enter task or type /help", id="chat-input"
                         )
+                    yield Static("Press Tab to autocomplete", id="tab-hint")
 
             # Resize divider — hidden until agents panel is visible
             yield ResizeDivider(id="resize-divider")
@@ -3446,13 +3458,20 @@ Be concise. Use the actual data from notes."""
         """Show/filter command suggestions when typing a slash command."""
         try:
             suggestions = self.query_one("#cmd-suggestions", CommandSuggestions)
+            hint = self.query_one("#tab-hint", Static)
+            inp = self.query_one("#chat-input", Input)
         except Exception:
             return
         val = event.value
         if val.startswith("/"):
             suggestions.update_suggestions(val)
+            show = bool(suggestions.display)
+            hint.display = show
+            inp.styles.width = "auto" if show else "1fr"
         else:
             suggestions.hide()
+            hint.display = False
+            inp.styles.width = "1fr"
 
     @on(Input.Submitted, "#chat-input")
     async def handle_submit(self, event: Input.Submitted) -> None:
@@ -3460,6 +3479,8 @@ Be concise. Use the actual data from notes."""
         # Hide suggestions on submit
         try:
             self.query_one("#cmd-suggestions", CommandSuggestions).hide()
+            self.query_one("#tab-hint", Static).display = False
+            self.query_one("#chat-input", Input).styles.width = "1fr"
         except Exception:
             pass
 
@@ -5037,6 +5058,8 @@ Be concise. Use the actual data from notes."""
             suggestions = self.query_one("#cmd-suggestions", CommandSuggestions)
             if suggestions.display:
                 suggestions.hide()
+                self.query_one("#tab-hint", Static).display = False
+                self.query_one("#chat-input", Input).styles.width = "1fr"
                 return
         except Exception:
             pass

--- a/pentestagent/interface/tui.py
+++ b/pentestagent/interface/tui.py
@@ -66,20 +66,29 @@ if TYPE_CHECKING:
     from ..agents.pa_agent import PentestAgentAgent
 
 
-SLASH_COMMANDS: List[tuple] = [
-    ("/assist", "Single AI call with tool execution"),
-    ("/agent", "Autonomous single-agent loop"),
-    ("/crew", "Multi-agent: orchestrator + workers"),
-    ("/interact", "Guided interactive chat"),
-    ("/target", "Set pentest target host"),
+# Each entry is (signature, description).
+# Signature tokens that are <placeholders> or [optionals] match any user input.
+COMMAND_SIGNATURES: List[tuple] = [
+    ("/assist <task>", "Single AI call with tool execution"),
+    ("/agent <task>", "Autonomous single-agent loop"),
+    ("/crew <task>", "Multi-agent: orchestrator + workers"),
+    ("/interact <task>", "Guided interactive chat"),
+    ("/target <host>", "Set pentest target host"),
     ("/tools", "List and manage available tools"),
     ("/notes", "Show saved findings"),
     ("/report", "Generate report from session"),
-    ("/mcp", "Manage MCP servers (list/add/remove)"),
-    ("/workspace", "Manage workspaces"),
+    ("/mcp list", "List configured MCP servers"),
+    ("/mcp add stdio <name> <command> [args...]", "Add STDIO MCP server"),
+    ("/mcp add sse <name> <url>", "Add SSE/HTTP MCP server"),
+    ("/workspace list", "List all workspaces"),
+    ("/workspace info <name>", "Show workspace info"),
+    ("/workspace note <text>", "Add note to active workspace"),
+    ("/workspace clear", "Deactivate current workspace"),
+    ("/workspace help", "Show workspace help"),
+    ("/workspace <name>", "Create or activate workspace"),
+    ("/spawn <task>", "Spawn child MCP agent"),
+    ("/despawn <server_name>", "Despawn child MCP agent"),
     ("/conversations", "Browse saved conversations"),
-    ("/spawn", "Spawn a child MCP agent"),
-    ("/despawn", "Despawn a child MCP agent"),
     ("/clear", "Clear chat history"),
     ("/memory", "Show memory statistics"),
     ("/token", "Show token usage statistics"),
@@ -87,6 +96,72 @@ SLASH_COMMANDS: List[tuple] = [
     ("/help", "Show help"),
     ("/quit", "Exit PentestAgent"),
 ]
+
+
+def _is_placeholder(token: str) -> bool:
+    return (token.startswith("<") and token.endswith(">")) or (
+        token.startswith("[") and token.endswith("]")
+    )
+
+
+def _sig_matches(sig: str, value: str) -> bool:
+    """Return True if the current input is a valid prefix path of the signature."""
+    sig_tokens = sig.split()
+    stripped = value.rstrip()
+    has_trailing = bool(value) and value[-1] == " "
+    val_tokens = stripped.split() if stripped else []
+
+    completed = val_tokens if has_trailing else val_tokens[:-1]
+    partial = "" if has_trailing else (val_tokens[-1] if val_tokens else "")
+
+    if len(completed) > len(sig_tokens):
+        return False
+
+    for i, tok in enumerate(completed):
+        sig_tok = sig_tokens[i]
+        if _is_placeholder(sig_tok):
+            continue
+        if sig_tok != tok:
+            return False
+
+    if partial:
+        next_idx = len(completed)
+        if next_idx >= len(sig_tokens):
+            return False
+        sig_tok = sig_tokens[next_idx]
+        if _is_placeholder(sig_tok):
+            return True
+        return sig_tok.startswith(partial)
+
+    return True
+
+
+def _get_display_parts(sig: str, value: str) -> tuple:
+    """Return (next_token, remaining_tokens_str) for rendering the suggestion row."""
+    sig_tokens = sig.split()
+    stripped = value.rstrip()
+    has_trailing = bool(value) and value[-1] == " "
+    val_tokens = stripped.split() if stripped else []
+
+    next_idx = len(val_tokens) if has_trailing else max(0, len(val_tokens) - 1)
+    next_tok = sig_tokens[next_idx] if next_idx < len(sig_tokens) else ""
+    remaining = " ".join(sig_tokens[next_idx + 1 :]) if next_idx + 1 < len(sig_tokens) else ""
+    return next_tok, remaining
+
+
+def _tab_complete(sig: str, value: str) -> str:
+    """Return new input value produced by Tab-completing the given signature."""
+    sig_tokens = sig.split()
+    stripped = value.rstrip()
+    has_trailing = bool(value) and value[-1] == " "
+    val_tokens = stripped.split() if stripped else []
+
+    next_idx = len(val_tokens) if has_trailing else max(0, len(val_tokens) - 1)
+    if next_idx >= len(sig_tokens):
+        return value
+
+    kept = val_tokens[:next_idx]
+    return " ".join(kept + [sig_tokens[next_idx]]) + " "
 
 
 class CommandSuggestions(Widget):
@@ -97,72 +172,71 @@ class CommandSuggestions(Widget):
         display: none;
         width: 100%;
         height: auto;
-        background: #1e1e1e;
+        max-height: 12;
+        background: #1a1a1a;
         border: round #383838;
         padding: 0;
         margin: 0 2;
-        max-height: 12;
         overflow-y: auto;
-        layer: overlay;
     }
     CommandSuggestions .suggestion-item {
         width: 100%;
         height: 1;
         padding: 0 1;
-        color: #9a9a9a;
     }
     CommandSuggestions .suggestion-item.--selected {
-        background: #2a2a2a;
-        color: #d4d4d4;
-    }
-    CommandSuggestions .suggestion-cmd {
-        color: #7dd3fc;
-    }
-    CommandSuggestions .suggestion-item.--selected .suggestion-cmd {
-        color: #38bdf8;
+        background: #252525;
     }
     """
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._items: List[tuple] = []
-        self._selected: int = -1
+        self._matches: List[tuple] = []
+        self._selected: int = 0
+        self._current_value: str = ""
 
     def compose(self) -> ComposeResult:
         return iter([])
 
-    def update_suggestions(self, text: str) -> None:
-        text_lower = text.lower()
-        self._items = [
-            (cmd, desc)
-            for cmd, desc in SLASH_COMMANDS
-            if cmd.startswith(text_lower)
+    def update_suggestions(self, value: str) -> None:
+        self._current_value = value
+        self._matches = [
+            (sig, desc)
+            for sig, desc in COMMAND_SIGNATURES
+            if _sig_matches(sig, value)
         ]
-        self._selected = 0 if self._items else -1
+        self._selected = 0
         self._rebuild()
-        self.display = bool(self._items)
+        self.display = bool(self._matches)
 
     def _rebuild(self) -> None:
         self.remove_children()
-        for i, (cmd, desc) in enumerate(self._items):
+        for i, (sig, desc) in enumerate(self._matches):
+            next_tok, remaining = _get_display_parts(sig, self._current_value)
             label = Text()
-            label.append(f"{cmd:<20}", style="bold #7dd3fc")
-            label.append(f" {desc}", style="#9a9a9a")
+            if next_tok:
+                if _is_placeholder(next_tok):
+                    label.append(next_tok, style="bold #f59e0b")
+                else:
+                    label.append(next_tok, style="bold #38bdf8")
+            if remaining:
+                label.append(f" {remaining}", style="#4a4a4a")
+            label.append(f"  {desc}", style="italic #4a4a4a")
             item = Static(label, classes="suggestion-item")
             if i == self._selected:
                 item.add_class("--selected")
             self.mount(item)
 
     def select_next(self) -> None:
-        if not self._items:
+        if not self._matches:
             return
-        self._selected = (self._selected + 1) % len(self._items)
+        self._selected = (self._selected + 1) % len(self._matches)
         self._highlight()
 
     def select_previous(self) -> None:
-        if not self._items:
+        if not self._matches:
             return
-        self._selected = (self._selected - 1) % len(self._items)
+        self._selected = (self._selected - 1) % len(self._matches)
         self._highlight()
 
     def _highlight(self) -> None:
@@ -172,14 +246,17 @@ class CommandSuggestions(Widget):
             else:
                 child.remove_class("--selected")
 
-    def get_selected_command(self) -> Optional[str]:
-        if self._selected >= 0 and self._selected < len(self._items):
-            return self._items[self._selected][0]
-        return None
+    def get_tab_completion(self) -> Optional[str]:
+        """Return new input value after Tab, or None if nothing to complete."""
+        if not self._matches or self._selected >= len(self._matches):
+            return None
+        sig = self._matches[self._selected][0]
+        return _tab_complete(sig, self._current_value)
 
     def hide(self) -> None:
-        self._items = []
-        self._selected = -1
+        self._matches = []
+        self._selected = 0
+        self._current_value = ""
         self.display = False
         self.remove_children()
 
@@ -3372,7 +3449,7 @@ Be concise. Use the actual data from notes."""
         except Exception:
             return
         val = event.value
-        if val.startswith("/") and " " not in val:
+        if val.startswith("/"):
             suggestions.update_suggestions(val)
         else:
             suggestions.hide()
@@ -5040,12 +5117,13 @@ Be concise. Use the actual data from notes."""
         if self._suggestions_visible():
             try:
                 suggestions = self.query_one("#cmd-suggestions", CommandSuggestions)
-                cmd = suggestions.get_selected_command()
-                if cmd:
+                new_value = suggestions.get_tab_completion()
+                if new_value is not None:
                     inp = self.query_one("#chat-input", Input)
-                    inp.value = cmd + " "
-                    inp.cursor_position = len(inp.value)
-                    suggestions.hide()
+                    inp.value = new_value
+                    inp.cursor_position = len(new_value)
+                    # Refresh suggestions for the new value
+                    suggestions.update_suggestions(new_value)
                     return
             except Exception:
                 pass

--- a/pentestagent/interface/tui.py
+++ b/pentestagent/interface/tui.py
@@ -145,7 +145,9 @@ def _get_display_parts(sig: str, value: str) -> tuple:
 
     next_idx = len(val_tokens) if has_trailing else max(0, len(val_tokens) - 1)
     next_tok = sig_tokens[next_idx] if next_idx < len(sig_tokens) else ""
-    remaining = " ".join(sig_tokens[next_idx + 1 :]) if next_idx + 1 < len(sig_tokens) else ""
+    remaining = (
+        " ".join(sig_tokens[next_idx + 1 :]) if next_idx + 1 < len(sig_tokens) else ""
+    )
     return next_tok, remaining
 
 
@@ -201,9 +203,7 @@ class CommandSuggestions(Widget):
     def update_suggestions(self, value: str) -> None:
         self._current_value = value
         self._matches = [
-            (sig, desc)
-            for sig, desc in COMMAND_SIGNATURES
-            if _sig_matches(sig, value)
+            (sig, desc) for sig, desc in COMMAND_SIGNATURES if _sig_matches(sig, value)
         ]
         self._selected = 0
         self._rebuild()

--- a/pentestagent/interface/tui.py
+++ b/pentestagent/interface/tui.py
@@ -66,6 +66,124 @@ if TYPE_CHECKING:
     from ..agents.pa_agent import PentestAgentAgent
 
 
+SLASH_COMMANDS: List[tuple] = [
+    ("/assist", "Single AI call with tool execution"),
+    ("/agent", "Autonomous single-agent loop"),
+    ("/crew", "Multi-agent: orchestrator + workers"),
+    ("/interact", "Guided interactive chat"),
+    ("/target", "Set pentest target host"),
+    ("/tools", "List and manage available tools"),
+    ("/notes", "Show saved findings"),
+    ("/report", "Generate report from session"),
+    ("/mcp", "Manage MCP servers (list/add/remove)"),
+    ("/workspace", "Manage workspaces"),
+    ("/conversations", "Browse saved conversations"),
+    ("/spawn", "Spawn a child MCP agent"),
+    ("/despawn", "Despawn a child MCP agent"),
+    ("/clear", "Clear chat history"),
+    ("/memory", "Show memory statistics"),
+    ("/token", "Show token usage statistics"),
+    ("/prompt", "Show system prompt"),
+    ("/help", "Show help"),
+    ("/quit", "Exit PentestAgent"),
+]
+
+
+class CommandSuggestions(Widget):
+    """Floating autocomplete dropdown for slash commands."""
+
+    DEFAULT_CSS = """
+    CommandSuggestions {
+        display: none;
+        width: 100%;
+        height: auto;
+        background: #1e1e1e;
+        border: round #383838;
+        padding: 0;
+        margin: 0 2;
+        max-height: 12;
+        overflow-y: auto;
+        layer: overlay;
+    }
+    CommandSuggestions .suggestion-item {
+        width: 100%;
+        height: 1;
+        padding: 0 1;
+        color: #9a9a9a;
+    }
+    CommandSuggestions .suggestion-item.--selected {
+        background: #2a2a2a;
+        color: #d4d4d4;
+    }
+    CommandSuggestions .suggestion-cmd {
+        color: #7dd3fc;
+    }
+    CommandSuggestions .suggestion-item.--selected .suggestion-cmd {
+        color: #38bdf8;
+    }
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._items: List[tuple] = []
+        self._selected: int = -1
+
+    def compose(self) -> ComposeResult:
+        return iter([])
+
+    def update_suggestions(self, text: str) -> None:
+        text_lower = text.lower()
+        self._items = [
+            (cmd, desc)
+            for cmd, desc in SLASH_COMMANDS
+            if cmd.startswith(text_lower)
+        ]
+        self._selected = 0 if self._items else -1
+        self._rebuild()
+        self.display = bool(self._items)
+
+    def _rebuild(self) -> None:
+        self.remove_children()
+        for i, (cmd, desc) in enumerate(self._items):
+            label = Text()
+            label.append(f"{cmd:<20}", style="bold #7dd3fc")
+            label.append(f" {desc}", style="#9a9a9a")
+            item = Static(label, classes="suggestion-item")
+            if i == self._selected:
+                item.add_class("--selected")
+            self.mount(item)
+
+    def select_next(self) -> None:
+        if not self._items:
+            return
+        self._selected = (self._selected + 1) % len(self._items)
+        self._highlight()
+
+    def select_previous(self) -> None:
+        if not self._items:
+            return
+        self._selected = (self._selected - 1) % len(self._items)
+        self._highlight()
+
+    def _highlight(self) -> None:
+        for i, child in enumerate(self.children):
+            if i == self._selected:
+                child.add_class("--selected")
+            else:
+                child.remove_class("--selected")
+
+    def get_selected_command(self) -> Optional[str]:
+        if self._selected >= 0 and self._selected < len(self._items):
+            return self._items[self._selected][0]
+        return None
+
+    def hide(self) -> None:
+        self._items = []
+        self._selected = -1
+        self.display = False
+        self.remove_children()
+
+
 def wrap_text_lines(text: str, width: int = 80) -> List[str]:
     """
     Wrap text content preserving line breaks and wrapping long lines.
@@ -2059,6 +2177,7 @@ class PentestAgentTUI(App):
                 yield Static("", id="header")
                 yield ScrollableContainer(id="chat-scroll")
                 yield StatusBar(id="status-bar")
+                yield CommandSuggestions(id="cmd-suggestions")
                 with Horizontal(id="input-container"):
                     yield Static("> ", id="chat-prompt")
                     if self.mcp_mode:
@@ -3245,9 +3364,28 @@ Be concise. Use the actual data from notes."""
         except Exception as e:
             self._add_system(f"[!] Report error: {e}")
 
+    @on(Input.Changed, "#chat-input")
+    def handle_input_changed(self, event: Input.Changed) -> None:
+        """Show/filter command suggestions when typing a slash command."""
+        try:
+            suggestions = self.query_one("#cmd-suggestions", CommandSuggestions)
+        except Exception:
+            return
+        val = event.value
+        if val.startswith("/") and " " not in val:
+            suggestions.update_suggestions(val)
+        else:
+            suggestions.hide()
+
     @on(Input.Submitted, "#chat-input")
     async def handle_submit(self, event: Input.Submitted) -> None:
         """Handle input submission"""
+        # Hide suggestions on submit
+        try:
+            self.query_one("#cmd-suggestions", CommandSuggestions).hide()
+        except Exception:
+            pass
+
         # MCP observation mode: the input is disabled at the widget level, but
         # guard here as well to be safe.
         if self.mcp_mode:
@@ -4817,6 +4955,14 @@ Be concise. Use the actual data from notes."""
         self.exit()
 
     def action_stop_agent(self) -> None:
+        # Hide suggestions on Escape without stopping the agent
+        try:
+            suggestions = self.query_one("#cmd-suggestions", CommandSuggestions)
+            if suggestions.display:
+                suggestions.hide()
+                return
+        except Exception:
+            pass
         if self._is_running:
             self._should_stop = True
             self._add_system("[!] Stopping...")
@@ -4889,10 +5035,39 @@ Be concise. Use the actual data from notes."""
     def action_show_help(self) -> None:
         self.push_screen(HelpScreen())
 
+    def action_focus_next(self) -> None:
+        """Complete suggestion with Tab, or fall back to normal focus cycling."""
+        if self._suggestions_visible():
+            try:
+                suggestions = self.query_one("#cmd-suggestions", CommandSuggestions)
+                cmd = suggestions.get_selected_command()
+                if cmd:
+                    inp = self.query_one("#chat-input", Input)
+                    inp.value = cmd + " "
+                    inp.cursor_position = len(inp.value)
+                    suggestions.hide()
+                    return
+            except Exception:
+                pass
+        super().action_focus_next()
+
     # ----- History navigation -----
 
+    def _suggestions_visible(self) -> bool:
+        try:
+            return self.query_one("#cmd-suggestions", CommandSuggestions).display
+        except Exception:
+            return False
+
     def action_history_up(self) -> None:
-        """Recall previous input into the chat field."""
+        """Navigate suggestions up, or recall previous input into the chat field."""
+        if self._suggestions_visible():
+            try:
+                self.query_one("#cmd-suggestions", CommandSuggestions).select_previous()
+            except Exception:
+                pass
+            return
+
         try:
             inp = self.query_one("#chat-input", Input)
         except Exception as e:
@@ -4919,7 +5094,14 @@ Be concise. Use the actual data from notes."""
         inp.value = self._cmd_history[self._history_index]
 
     def action_history_down(self) -> None:
-        """Recall next input (or clear when at end)."""
+        """Navigate suggestions down, or recall next input (or clear when at end)."""
+        if self._suggestions_visible():
+            try:
+                self.query_one("#cmd-suggestions", CommandSuggestions).select_next()
+            except Exception:
+                pass
+            return
+
         try:
             inp = self.query_one("#chat-input", Input)
         except Exception as e:


### PR DESCRIPTION
- Adds an interactive autocomplete dropdown to the TUI chat input for slash commands.
- Introduces a CommandSuggestions widget that appears when the user types /, showing matching commands filtered in real time.
- Supports hierarchical multi-level matching (e.g. /mcp → /mcp add → /mcp add stdio …), with placeholders like <task> rendered distinctively.
- Tab completes the highlighted suggestion one token at a time; Up/Down arrows navigate the list.
- Escape dismisses the dropdown without interrupting a running agent.
- A subtle "Press Tab to autocomplete" hint is shown next to the input while the dropdown is open.

<img width="1832" height="592" alt="imagen" src="https://github.com/user-attachments/assets/bcbbb6a1-c850-4660-9dbf-1f280219a46d" />

