### PR TITLE
feat(tui): persist and restore session state across restarts

### DIFF
--- a/pentestagent/interface/tui.py
+++ b/pentestagent/interface/tui.py
@@ -30,7 +30,7 @@ from textual.screen import ModalScreen
 from textual.scrollbar import ScrollBar, ScrollBarRender
 from textual.timer import Timer
 from textual.widget import Widget
-from textual.widgets import Button, Input, Static, Tree
+from textual.widgets import Button, Input, Static, Switch, Tree
 from textual.widgets.tree import TreeNode
 
 from ..config.constants import DEFAULT_MODEL
@@ -555,6 +555,15 @@ class ConversationsScreen(ModalScreen):
 
     CSS = """
     ConversationsScreen { align: center middle; }
+    #conv-prefs-row {
+        height: 3;
+        align: center middle;
+        padding: 0 2;
+    }
+    #conv-prefs-label {
+        padding: 0 1;
+        color: #9a9a9a;
+    }
     """
 
     def __init__(self, conversations: list, store) -> None:
@@ -575,6 +584,11 @@ class ConversationsScreen(ModalScreen):
                         Static("Select a conversation to preview.", id="conv-preview"),
                         id="conv-preview-scroll",
                     )
+            with Horizontal(id="conv-prefs-row"):
+                yield Switch(id="conv-auto-reload", value=False)
+                yield Static(
+                    "Auto-reload last session on startup", id="conv-prefs-label"
+                )
             with Center():
                 yield Button("Restore", id="conv-restore", disabled=True)
                 yield Button("Close", id="conv-close")
@@ -596,6 +610,40 @@ class ConversationsScreen(ModalScreen):
                 pass
         try:
             tree.focus()
+        except Exception:
+            pass
+        # Load auto-reload preference
+        try:
+            import json as _json
+
+            from ..workspaces.utils import get_preferences_file
+
+            prefs_file = get_preferences_file()
+            if prefs_file.exists():
+                prefs = _json.loads(prefs_file.read_text(encoding="utf-8"))
+                value = bool(prefs.get("auto_reload_session", False))
+            else:
+                value = False
+            self.query_one("#conv-auto-reload", Switch).value = value
+        except Exception:
+            pass
+
+    @on(Switch.Changed, "#conv-auto-reload")
+    def on_auto_reload_changed(self, event: Switch.Changed) -> None:
+        try:
+            import json as _json
+
+            from ..workspaces.utils import get_preferences_file
+
+            prefs_file = get_preferences_file()
+            prefs = {}
+            if prefs_file.exists():
+                try:
+                    prefs = _json.loads(prefs_file.read_text(encoding="utf-8"))
+                except Exception:
+                    prefs = {}
+            prefs["auto_reload_session"] = event.value
+            prefs_file.write_text(_json.dumps(prefs, indent=2), encoding="utf-8")
         except Exception:
             pass
 
@@ -2712,7 +2760,9 @@ class PentestAgentTUI(App):
         if history_index == -1:
             return False
 
-        self.agent.conversation_history = self.agent.conversation_history[:history_index]
+        self.agent.conversation_history = self.agent.conversation_history[
+            :history_index
+        ]
         for widget in reversed(self._chat_widgets[widget_index:]):
             try:
                 widget.remove()
@@ -3093,16 +3143,26 @@ class PentestAgentTUI(App):
                 encoding="utf-8",
             )
         except Exception as e:
-            logging.getLogger(__name__).exception(
-                "Failed to save session state: %s", e
-            )
+            logging.getLogger(__name__).exception("Failed to save session state: %s", e)
 
     async def _restore_session(self) -> None:
-        """On startup, restore last session from session.json if present."""
+        """On startup, restore last session from session.json if the preference is enabled."""
         try:
             import json as _json
 
-            from ..workspaces.utils import get_session_file
+            from ..workspaces.utils import get_preferences_file, get_session_file
+
+            # Check user preference — default is disabled
+            prefs_file = get_preferences_file()
+            auto_reload = False
+            if prefs_file.exists():
+                try:
+                    prefs = _json.loads(prefs_file.read_text(encoding="utf-8"))
+                    auto_reload = bool(prefs.get("auto_reload_session", False))
+                except Exception:
+                    pass
+            if not auto_reload:
+                return
 
             session_file = get_session_file()
             if not session_file.exists():
@@ -3128,9 +3188,7 @@ class PentestAgentTUI(App):
                 except Exception:
                     pass
         except Exception as e:
-            logging.getLogger(__name__).exception(
-                "Failed to restore session: %s", e
-            )
+            logging.getLogger(__name__).exception("Failed to restore session: %s", e)
 
     def _set_target(self, cmd: str) -> None:
         """Set the target for the engagement"""

--- a/pentestagent/interface/tui.py
+++ b/pentestagent/interface/tui.py
@@ -2334,6 +2334,8 @@ class PentestAgentTUI(App):
                 except Exception:
                     self._add_system(f"  Target: {self.target}")
 
+            await self._restore_session()
+
         except Exception as e:
             import traceback
 
@@ -3003,6 +3005,7 @@ class PentestAgentTUI(App):
             )
             if conv_id:
                 self._current_conv_id = conv_id
+                await self._save_session_state()
         except Exception as e:
             logging.getLogger(__name__).exception(
                 "Failed to auto-save conversation: %s", e
@@ -3067,6 +3070,67 @@ class PentestAgentTUI(App):
                 "Failed to restore conversation: %s", e
             )
             self._add_system(f"[!] Restore failed: {e}")
+
+    async def _save_session_state(self) -> None:
+        """Persist current conv_id, mode, and target to session.json."""
+        if not self._current_conv_id:
+            return
+        try:
+            import json as _json
+
+            from ..workspaces.utils import get_session_file
+
+            session_file = get_session_file()
+            session_file.write_text(
+                _json.dumps(
+                    {
+                        "conv_id": self._current_conv_id,
+                        "mode": self._mode,
+                        "target": self.target,
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+        except Exception as e:
+            logging.getLogger(__name__).exception(
+                "Failed to save session state: %s", e
+            )
+
+    async def _restore_session(self) -> None:
+        """On startup, restore last session from session.json if present."""
+        try:
+            import json as _json
+
+            from ..workspaces.utils import get_session_file
+
+            session_file = get_session_file()
+            if not session_file.exists():
+                return
+            data = _json.loads(session_file.read_text(encoding="utf-8"))
+            conv_id = data.get("conv_id")
+            mode = data.get("mode", "assist")
+            saved_target = data.get("target")
+
+            if conv_id:
+                await self._restore_conversation(conv_id)
+
+            if mode in ("assist", "agent", "crew", "interact"):
+                self._mode = mode
+                self._set_status("idle", mode)
+
+            if saved_target and not self.target:
+                self.target = saved_target
+                if self.agent:
+                    self.agent.target = saved_target
+                try:
+                    self._update_header(target=saved_target)
+                except Exception:
+                    pass
+        except Exception as e:
+            logging.getLogger(__name__).exception(
+                "Failed to restore session: %s", e
+            )
 
     def _set_target(self, cmd: str) -> None:
         """Set the target for the engagement"""
@@ -3445,6 +3509,15 @@ Be concise. Use the actual data from notes."""
         elif cmd_lower == "/clear":
             await self._save_current_conversation()
             self._current_conv_id = None
+            # Remove autosave session pointer so next startup starts fresh
+            try:
+                from ..workspaces.utils import get_session_file
+
+                sf = get_session_file()
+                if sf.exists():
+                    sf.unlink()
+            except Exception:
+                pass
             scroll = self.query_one("#chat-scroll", ScrollableContainer)
             await scroll.remove_children()
             self._chat_widgets.clear()
@@ -5092,6 +5165,8 @@ Be concise. Use the actual data from notes."""
 
     async def on_unmount(self) -> None:
         """Cleanup"""
+        await self._save_current_conversation()
+
         if self.mcp_manager:
             try:
                 await self.mcp_manager.disconnect_all()

--- a/pentestagent/workspaces/utils.py
+++ b/pentestagent/workspaces/utils.py
@@ -115,6 +115,23 @@ def resolve_knowledge_paths(root: Optional[Path] = None) -> dict:
     return paths
 
 
+def get_session_file(root: Optional[Path] = None) -> Path:
+    """Return the path to session.json for the active workspace.
+
+    Stores at workspaces/{active}/memory/session.json or conversations/session.json
+    (global fallback), alongside the conversations directory.
+    """
+    root = Path(root or "./")
+    wm = WorkspaceManager(root=root)
+    active = wm.get_active()
+    if active:
+        base = root / "workspaces" / active / "memory"
+    else:
+        base = root / "conversations"
+    base.mkdir(parents=True, exist_ok=True)
+    return base / "session.json"
+
+
 def export_workspace(
     name: str, output: Optional[Path] = None, root: Optional[Path] = None
 ) -> Path:

--- a/pentestagent/workspaces/utils.py
+++ b/pentestagent/workspaces/utils.py
@@ -132,6 +132,23 @@ def get_session_file(root: Optional[Path] = None) -> Path:
     return base / "session.json"
 
 
+def get_preferences_file(root: Optional[Path] = None) -> Path:
+    """Return the path to prefs.json for the active workspace.
+
+    Stores at workspaces/{active}/memory/prefs.json or conversations/prefs.json
+    (global fallback), alongside session.json.
+    """
+    root = Path(root or "./")
+    wm = WorkspaceManager(root=root)
+    active = wm.get_active()
+    if active:
+        base = root / "workspaces" / active / "memory"
+    else:
+        base = root / "conversations"
+    base.mkdir(parents=True, exist_ok=True)
+    return base / "prefs.json"
+
+
 def export_workspace(
     name: str, output: Optional[Path] = None, root: Optional[Path] = None
 ) -> Path:


### PR DESCRIPTION
- Adds the ability to automatically resume the last conversation when the TUI starts, with a per-workspace toggle to enable it.
- On startup, if the "Auto-reload last session" preference is enabled, the TUI reads session.json and restores the last conversation, mode (assist/agent/crew/interact), and target.
- Session state (conv_id, mode, target) is written to session.json every time the conversation is auto-saved, and also flushed on clean exit via on_unmount.
- Running /clear deletes session.json so the next startup begins fresh.
- The preference is toggled via a Switch in the Conversations screen (/conversations) and persisted in prefs.json.
- Both files are scoped to the active workspace (workspaces/<name>/memory/) with a global fallback under conversations/, managed by two new helpers — get_session_file() and get_preferences_file() — in [pentestagent/workspaces/utils.py].