### PR TITLE
Fix DeepSeek tool result sequencing

### DIFF
--- a/pentestagent/agents/base_agent.py
+++ b/pentestagent/agents/base_agent.py
@@ -1,6 +1,7 @@
 """Base agent class for PentestAgent."""
 
 import asyncio
+import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, AsyncIterator, List, Optional
@@ -16,6 +17,7 @@ if TYPE_CHECKING:
     from ..tools import Tool
 
 _TOOL_LIMIT = 128
+_DEFAULT_MAX_CONCURRENT_TOOL_CALLS = 4
 
 
 @dataclass
@@ -223,6 +225,14 @@ class BaseAgent(ABC):
 
         # Ensure agent starts idle
         self.state_manager.transition_to(AgentState.IDLE)
+        raw_tool_call_concurrency = os.getenv(
+            "PENTESTAGENT_MAX_CONCURRENT_TOOL_CALLS",
+            str(_DEFAULT_MAX_CONCURRENT_TOOL_CALLS),
+        )
+        try:
+            self._tool_call_concurrency = max(1, int(raw_tool_call_concurrency))
+        except ValueError:
+            self._tool_call_concurrency = _DEFAULT_MAX_CONCURRENT_TOOL_CALLS
 
     @abstractmethod
     def get_system_prompt(self, mode: str = "agent") -> str:
@@ -536,6 +546,40 @@ class BaseAgent(ABC):
                 return {"raw": args}
         return args
 
+    @staticmethod
+    def _get_tool_call_name(call: Any) -> str:
+        """Extract the tool name from an LLM tool call object."""
+        if hasattr(call, "function"):
+            return call.function.name
+        if isinstance(call, ToolCall):
+            return call.name
+        if isinstance(call, dict):
+            return call.get("name", "")
+        return ""
+
+    def _is_tool_concurrent_safe(self, call: Any) -> bool:
+        """
+        Determine if a tool call is safe to run in parallel with other tool calls.
+
+        Tool registrations can set metadata["supports_concurrent_execution"] = False
+        for stateful/shared tools.
+        """
+        name = self._get_tool_call_name(call)
+        tool = self._find_tool(name)
+        if not tool:
+            return True
+
+        supports_concurrent_execution = tool.metadata.get(
+            "supports_concurrent_execution"
+        )
+        if isinstance(supports_concurrent_execution, bool):
+            return supports_concurrent_execution
+        return True
+
+    def _is_concurrent_batch_safe(self, tool_calls: List[Any]) -> bool:
+        """Return True if every requested tool call is safe for concurrent execution."""
+        return all(self._is_tool_concurrent_safe(call) for call in tool_calls)
+
     async def _execute_single(self, i: int, call: Any) -> ToolResult:
         """Execute a single tool call and return the result."""
         # Extract tool call id, name and arguments
@@ -549,6 +593,9 @@ class BaseAgent(ABC):
         if hasattr(call, "function"):
             name = call.function.name
             arguments = self._parse_arguments(call)
+        elif isinstance(call, ToolCall):
+            name = call.name
+            arguments = call.arguments
         elif isinstance(call, dict):
             name = call.get("name", "")
             arguments = call.get("arguments", {})
@@ -687,12 +734,47 @@ class BaseAgent(ABC):
             )
 
     async def _execute_tools(self, tool_calls: List[Any]) -> List[ToolResult]:
-        """Execute tool calls concurrently and return all results."""
+        """
+        Execute tool calls and return all results.
+
+        Concurrency is bounded and disabled for unsafe tool combinations.
+        """
+        if not tool_calls:
+            return []
+        if len(tool_calls) == 1:
+            return [await self._execute_single(0, tool_calls[0])]
+
+        if not self._is_concurrent_batch_safe(tool_calls):
+            return [
+                await self._execute_single(i, call) for i, call in enumerate(tool_calls)
+            ]
+
+        semaphore = asyncio.Semaphore(self._tool_call_concurrency)
         tasks = [
-            asyncio.ensure_future(self._execute_single(i, call))
+            asyncio.create_task(self._execute_single_indexed(i, call, semaphore))
             for i, call in enumerate(tool_calls)
         ]
-        return list(await asyncio.gather(*tasks))
+
+        try:
+            results = await asyncio.gather(*tasks)
+        finally:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+        # Preserve original input order in returned tool result list.
+        results_by_index = sorted(results, key=lambda item: item[0])
+        return [result for _, result in results_by_index]
+
+    async def _execute_single_indexed(
+        self, i: int, call: Any, semaphore: asyncio.Semaphore | None = None
+    ) -> tuple[int, ToolResult]:
+        """Execute one indexed tool call and return its tuple result."""
+        if semaphore is not None:
+            async with semaphore:
+                return i, await self._execute_single(i, call)
+        return i, await self._execute_single(i, call)
 
     def _find_tool(self, name: str) -> Optional["Tool"]:
         """
@@ -1124,17 +1206,9 @@ Call create_plan with the new steps OR feasible=False."""
                 yield assistant_msg
 
                 self.state_manager.transition_to(AgentState.EXECUTING)
+                all_tool_results = await self._execute_tools(response.tool_calls)
 
-                tasks = [
-                    asyncio.ensure_future(self._execute_single(i, tc))
-                    for i, tc in enumerate(response.tool_calls)
-                ]
-
-                all_tool_results = []
-                for coro in asyncio.as_completed(tasks):
-                    tool_result = await coro
-                    all_tool_results.append(tool_result)
-
+                for tool_result in all_tool_results:
                     if tool_result.suggested_tools:
                         self.suggested_tools += tool_result.suggested_tools
                         self.deduplicate_suggested_tools()

--- a/pentestagent/tools/browser/__init__.py
+++ b/pentestagent/tools/browser/__init__.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
         required=["action"],
     ),
     category="web",
+    metadata={"supports_concurrent_execution": False},
 )
 async def browser(arguments: dict, runtime: "Runtime") -> str:
     """

--- a/pentestagent/tools/registry.py
+++ b/pentestagent/tools/registry.py
@@ -125,7 +125,11 @@ _tools: Dict[str, Tool] = {}
 
 
 def register_tool(
-    name: str, description: str, schema: ToolSchema, category: str = "general"
+    name: str,
+    description: str,
+    schema: ToolSchema,
+    category: str = "general",
+    metadata: Optional[Dict[str, Any]] = None,
 ) -> Callable:
     """
     Decorator to register a tool.
@@ -135,6 +139,7 @@ def register_tool(
         description: Description of what the tool does
         schema: The parameter schema
         category: Tool category for organization
+        metadata: Optional metadata for tool behavior flags
 
     Returns:
         Decorator function
@@ -151,6 +156,7 @@ def register_tool(
             schema=schema,
             execute_fn=wrapper,
             category=category,
+            metadata=metadata or {},
         )
         _tools[name] = tool
         return wrapper

--- a/tests/integration/test_agent_loop.py
+++ b/tests/integration/test_agent_loop.py
@@ -1,7 +1,7 @@
 """Integration tests for the agent loop using a minimal concrete agent."""
 
 import asyncio
-from typing import AsyncIterator, List
+from typing import List
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -10,17 +10,18 @@ from pentestagent.agents.base_agent import AgentMessage, BaseAgent, ToolCall, To
 from pentestagent.agents.state import AgentState
 from pentestagent.tools.registry import Tool, ToolSchema
 
-
 # ---------------------------------------------------------------------------
 # Minimal concrete BaseAgent for testing
 # ---------------------------------------------------------------------------
+
 
 class _MinimalAgent(BaseAgent):
     """Concrete implementation of BaseAgent for unit testing."""
 
     def __init__(self, llm, tools, runtime, max_iterations=5):
-        super().__init__(llm=llm, tools=tools, runtime=runtime,
-                         max_iterations=max_iterations)
+        super().__init__(
+            llm=llm, tools=tools, runtime=runtime, max_iterations=max_iterations
+        )
         self._system_prompt = "You are a test agent."
 
     def get_system_prompt(self, mode: str = "agent") -> str:
@@ -31,15 +32,18 @@ class _MinimalAgent(BaseAgent):
 # Factories
 # ---------------------------------------------------------------------------
 
+
 def _make_runtime():
     rt = MagicMock()
     rt.plan = MagicMock()
     rt.plan.clear = MagicMock()
     rt.plan.is_complete = MagicMock(return_value=False)
     rt.plan.has_failure = MagicMock(return_value=False)
-    rt.execute_command = AsyncMock(return_value=MagicMock(
-        exit_code=0, stdout="ok", stderr="", success=True, output="ok"
-    ))
+    rt.execute_command = AsyncMock(
+        return_value=MagicMock(
+            exit_code=0, stdout="ok", stderr="", success=True, output="ok"
+        )
+    )
     rt.is_running = AsyncMock(return_value=True)
     return rt
 
@@ -75,6 +79,7 @@ def _make_llm(responses=None):
 def _echo_tool() -> Tool:
     async def fn(arguments, runtime):
         return f"echo: {arguments.get('msg', '')}"
+
     return Tool(
         name="echo",
         description="Echo a message",
@@ -97,6 +102,7 @@ async def _collect(agent: BaseAgent, message: str) -> List[AgentMessage]:
 # AgentMessage
 # ---------------------------------------------------------------------------
 
+
 class TestAgentMessage:
     def test_to_llm_format_basic(self):
         msg = AgentMessage(role="user", content="hello")
@@ -116,6 +122,7 @@ class TestAgentMessage:
         msg = AgentMessage(role="assistant", content="", tool_calls=[tc])
         fmt = msg.to_llm_format()
         import json
+
         args = fmt["tool_calls"][0]["function"]["arguments"]
         assert json.loads(args)["key"] == "val"
 
@@ -124,23 +131,19 @@ class TestAgentMessage:
 # BaseAgent initialisation
 # ---------------------------------------------------------------------------
 
+
 class TestBaseAgentInit:
     def test_initial_state_idle(self):
-        agent = _MinimalAgent(
-            llm=_make_llm(), tools=[], runtime=_make_runtime()
-        )
+        agent = _MinimalAgent(llm=_make_llm(), tools=[], runtime=_make_runtime())
         assert agent.state_manager.current_state == AgentState.IDLE
 
     def test_conversation_history_empty(self):
-        agent = _MinimalAgent(
-            llm=_make_llm(), tools=[], runtime=_make_runtime()
-        )
+        agent = _MinimalAgent(llm=_make_llm(), tools=[], runtime=_make_runtime())
         assert agent.conversation_history == []
 
     def test_max_iterations_stored(self):
         agent = _MinimalAgent(
-            llm=_make_llm(), tools=[], runtime=_make_runtime(),
-            max_iterations=7
+            llm=_make_llm(), tools=[], runtime=_make_runtime(), max_iterations=7
         )
         assert agent.max_iterations == 7
 
@@ -154,6 +157,7 @@ class TestBaseAgentInit:
 # ToolCall / ToolResult dataclasses
 # ---------------------------------------------------------------------------
 
+
 class TestToolCallToolResult:
     def test_tool_call_fields(self):
         tc = ToolCall(id="abc", name="terminal", arguments={"command": "id"})
@@ -166,8 +170,9 @@ class TestToolCallToolResult:
         assert tr.success is True
 
     def test_tool_result_with_error(self):
-        tr = ToolResult(tool_call_id="1", tool_name="echo",
-                        error="something failed", success=False)
+        tr = ToolResult(
+            tool_call_id="1", tool_name="echo", error="something failed", success=False
+        )
         assert tr.success is False
         assert tr.error == "something failed"
 
@@ -175,6 +180,7 @@ class TestToolCallToolResult:
 # ---------------------------------------------------------------------------
 # Security: prompt injection in system prompt
 # ---------------------------------------------------------------------------
+
 
 class TestPromptInjectionResistance:
     def test_system_prompt_does_not_include_user_input(self, tmp_path):
@@ -202,6 +208,7 @@ class TestPromptInjectionResistance:
 # State transitions during loop
 # ---------------------------------------------------------------------------
 
+
 class TestAgentStateTransitions:
     def test_state_is_thinking_after_start(self):
         agent = _MinimalAgent(llm=_make_llm(), tools=[], runtime=_make_runtime())
@@ -221,11 +228,12 @@ class TestAgentStateTransitions:
 # Integration: workspace + tool executor flow
 # ---------------------------------------------------------------------------
 
+
 class TestWorkspaceToolExecutorFlow:
     @pytest.mark.asyncio
     async def test_tool_executor_runs_tool_successfully(self, tmp_path):
-        from pentestagent.tools.executor import ToolExecutor
         from pentestagent.runtime.runtime import LocalRuntime
+        from pentestagent.tools.executor import ToolExecutor
 
         rt = LocalRuntime()
         await rt.start()
@@ -255,7 +263,8 @@ class TestWorkspaceToolExecutorFlow:
     async def test_scope_enforcement_with_workspace(self, tmp_path):
         from pentestagent.workspaces.manager import WorkspaceManager
         from pentestagent.workspaces.validation import (
-            gather_candidate_targets, is_target_in_scope
+            gather_candidate_targets,
+            is_target_in_scope,
         )
 
         mgr = WorkspaceManager(root=tmp_path)
@@ -269,4 +278,202 @@ class TestWorkspaceToolExecutorFlow:
 
         for candidate in candidates:
             in_scope = is_target_in_scope(candidate, allowed)
-            assert in_scope is False, f"Out-of-scope target {candidate} should be rejected"
+            assert (
+                in_scope is False
+            ), f"Out-of-scope target {candidate} should be rejected"
+
+
+class TestToolExecutionBatching:
+    @pytest.mark.asyncio
+    async def test_execute_tools_respects_concurrency_limit(self):
+        state = {"running": 0, "max_running": 0}
+        lock = asyncio.Lock()
+
+        async def execute(arguments, _runtime):
+            async with lock:
+                state["running"] += 1
+                state["max_running"] = max(state["max_running"], state["running"])
+
+            await asyncio.sleep(0.05)
+
+            async with lock:
+                state["running"] -= 1
+
+            return arguments["value"]
+
+        tool = Tool(
+            name="bounded_tool",
+            description="A tool that sleeps briefly.",
+            schema=ToolSchema(
+                properties={"value": {"type": "string"}}, required=["value"]
+            ),
+            execute_fn=execute,
+        )
+        agent = _MinimalAgent(llm=_make_llm(), tools=[tool], runtime=_make_runtime())
+        agent._tool_call_concurrency = 2
+
+        calls = [
+            ToolCall(id=f"call_{i}", name="bounded_tool", arguments={"value": str(i)})
+            for i in range(6)
+        ]
+        results = await agent._execute_tools(calls)
+
+        assert len(results) == 6
+        assert state["max_running"] <= 2
+        assert [r.tool_call_id for r in results] == [f"call_{i}" for i in range(6)]
+
+    @pytest.mark.asyncio
+    async def test_execute_tools_preserves_tool_result_order(self):
+        async def execute(arguments, _runtime):
+            await asyncio.sleep(arguments["delay"])
+            return arguments["value"]
+
+        tool = Tool(
+            name="ordered_tool",
+            description="A tool that sleeps briefly.",
+            schema=ToolSchema(
+                properties={"value": {"type": "string"}, "delay": {"type": "number"}}
+            ),
+            execute_fn=execute,
+        )
+        agent = _MinimalAgent(llm=_make_llm(), tools=[tool], runtime=_make_runtime())
+        agent._tool_call_concurrency = 10
+
+        calls = [
+            ToolCall(
+                id="slow",
+                name="ordered_tool",
+                arguments={"value": "slow", "delay": 0.05},
+            ),
+            ToolCall(
+                id="fast",
+                name="ordered_tool",
+                arguments={"value": "fast", "delay": 0.0},
+            ),
+        ]
+        results = await agent._execute_tools(calls)
+
+        assert results[0].result == "slow"
+        assert results[1].result == "fast"
+
+    @pytest.mark.asyncio
+    async def test_execute_tools_serializes_unsafe_browser_calls(self):
+        state = {"running": 0, "max_running": 0}
+        lock = asyncio.Lock()
+
+        async def safe_execute(arguments, _runtime):
+            async with lock:
+                state["running"] += 1
+                state["max_running"] = max(state["max_running"], state["running"])
+
+            await asyncio.sleep(0.05)
+
+            async with lock:
+                state["running"] -= 1
+
+            return arguments["value"]
+
+        browser_tool = Tool(
+            name="browser",
+            description="A shared browser tool.",
+            schema=ToolSchema(
+                properties={"value": {"type": "string"}}, required=["value"]
+            ),
+            execute_fn=safe_execute,
+            metadata={"supports_concurrent_execution": False},
+        )
+        safe_tool = Tool(
+            name="safe_tool",
+            description="A safe tool.",
+            schema=ToolSchema(
+                properties={"value": {"type": "string"}}, required=["value"]
+            ),
+            execute_fn=safe_execute,
+        )
+        agent = _MinimalAgent(
+            llm=_make_llm(),
+            tools=[browser_tool, safe_tool],
+            runtime=_make_runtime(),
+        )
+        agent._tool_call_concurrency = 10
+
+        calls = [
+            ToolCall(id="browser", name="browser", arguments={"value": "browser"}),
+            ToolCall(id="safe", name="safe_tool", arguments={"value": "safe"}),
+        ]
+        results = await agent._execute_tools(calls)
+
+        assert [r.result for r in results] == ["browser", "safe"]
+        assert state["max_running"] <= 1
+
+
+class TestToolCallMessageOrdering:
+    def test_format_messages_keeps_tool_calls_before_tool_results(self):
+        agent = _MinimalAgent(llm=_make_llm(), tools=[], runtime=_make_runtime())
+        agent.conversation_history = [
+            AgentMessage(role="user", content="run command with tool"),
+            AgentMessage(
+                role="assistant",
+                content="",
+                tool_calls=[
+                    ToolCall(
+                        id="tool_1",
+                        name="terminal",
+                        arguments={"command": "echo ok"},
+                    )
+                ],
+            ),
+            AgentMessage(
+                role="tool_result",
+                content="",
+                tool_results=[
+                    ToolResult(
+                        tool_call_id="tool_1",
+                        tool_name="terminal",
+                        result="ok",
+                        success=True,
+                    )
+                ],
+            ),
+        ]
+
+        messages = agent._format_messages_for_llm()
+
+        assert messages[0]["role"] == "user"
+        assert messages[1]["role"] == "assistant"
+        assert messages[1]["tool_calls"][0]["function"]["name"] == "terminal"
+        assert messages[2]["role"] == "tool"
+        assert messages[2]["tool_call_id"] == "tool_1"
+
+    def test_format_messages_uses_ordered_tool_results(self):
+        agent = _MinimalAgent(llm=_make_llm(), tools=[], runtime=_make_runtime())
+        agent.conversation_history = [
+            AgentMessage(
+                role="assistant",
+                content="",
+                tool_calls=[
+                    ToolCall(id="tool_1", name="safe_tool", arguments={"value": "a"}),
+                    ToolCall(id="tool_2", name="safe_tool", arguments={"value": "b"}),
+                ],
+            ),
+            AgentMessage(
+                role="tool_result",
+                content="",
+                tool_results=[
+                    ToolResult(
+                        tool_call_id="tool_1", tool_name="safe_tool", result="a"
+                    ),
+                    ToolResult(
+                        tool_call_id="tool_2", tool_name="safe_tool", result="b"
+                    ),
+                ],
+            ),
+        ]
+
+        messages = agent._format_messages_for_llm()
+        assert len(messages) == 3
+        assert messages[0]["role"] == "assistant"
+        assert len(messages[0]["tool_calls"]) == 2
+        assert messages[1]["role"] == "tool"
+        assert messages[1]["tool_call_id"] == "tool_1"
+        assert messages[2]["tool_call_id"] == "tool_2"


### PR DESCRIPTION
## Summary\n\n- Add bounded, optional parallel tool execution with per-tool concurrency metadata in BaseAgent.\n- Keep browser/tool stateful calls serialized by default.\n- Extend tool registry to carry metadata flags used to control concurrency safety.\n- Mark browser tool as non-concurrently-safe with metadata.\n- Add regression tests for tool batching behavior and tool-result ordering guarantees (DeepSeek-compatible sequencing).\n\n## Validation\n\n- python -m pytest -q tests/integration/test_agent_loop.py\n- uv run --no-project --python 3.14 --with pytest --with pytest-asyncio --with pytest-mock --with pyyaml --with numpy --with networkx --with jinja2 python -m pytest -q tests/integration/test_agent_loop.py\n- uv run --no-project --python 3.14 --with ruff ruff check pentestagent/agents/base_agent.py pentestagent/tools/registry.py pentestagent/tools/browser/__init__.py tests/integration/test_agent_loop.py\n- uv run --no-project --python 3.14 --with black black --check pentestagent/agents/base_agent.py pentestagent/tools/registry.py pentestagent/tools/browser/__init__.py tests/integration/test_agent_loop.py\n- python -m compileall -q pentestagent/agents/base_agent.py pentestagent/tools/registry.py pentestagent/tools/browser/__init__.py tests/integration/test_agent_loop.py\n\nCloses #80.,